### PR TITLE
Fix: "hot water" title on water page

### DIFF
--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -38,6 +38,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m8(w) => "الوزن ${w} ز";
 
+  static String m9(temp) => "درجة حرارة الماء ${temp} ° C";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "beans": MessageLookupByLibrary.simpleMessage("فول"),
@@ -486,6 +488,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "screenSteamTwotapMode":
             MessageLookupByLibrary.simpleMessage("وضع البخار بنقرتين:"),
         "screenWaterWeightG": m8,
+        "screenHotWaterTemperaturs": m9,
         "settings": MessageLookupByLibrary.simpleMessage("إعدادات"),
         "show": MessageLookupByLibrary.simpleMessage("يعرض"),
         "start": MessageLookupByLibrary.simpleMessage("يبدأ"),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -38,6 +38,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m8(w) => "Gewicht ${w} g";
 
+  static String m9(temp) => "Wasser Temperatur ${temp} °C";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "beans": MessageLookupByLibrary.simpleMessage("Bohnen"),
@@ -496,6 +498,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "screenSteamTwotapMode":
             MessageLookupByLibrary.simpleMessage("Dampf two-tap mode:"),
         "screenWaterWeightG": m8,
+        "screenHotWaterTemperaturs": m9,
         "settings": MessageLookupByLibrary.simpleMessage("Einstellungen"),
         "show": MessageLookupByLibrary.simpleMessage("Anzeigen"),
         "start": MessageLookupByLibrary.simpleMessage("Start"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -38,6 +38,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m8(w) => "Weight ${w} g";
 
+  static String m9(temp) => "Water Temperature ${temp} °C";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "beans": MessageLookupByLibrary.simpleMessage("Beans"),
@@ -493,6 +495,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "screenSteamTwotapMode":
             MessageLookupByLibrary.simpleMessage("Steam two-tap mode:"),
         "screenWaterWeightG": m8,
+        "screenHotWaterTemperaturs": m9,
         "settings": MessageLookupByLibrary.simpleMessage("Settings"),
         "show": MessageLookupByLibrary.simpleMessage("Show"),
         "start": MessageLookupByLibrary.simpleMessage("Start"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -32,7 +32,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m5(temp) => "Stop at Temperature ${temp} °C";
 
-  static String m6(temp) => "Steam Temperaturs ${temp} °C";
+  static String m6(temp) => "Steam Temperature ${temp} °C";
 
   static String m7(t) => "Timer ${t} s";
 

--- a/lib/generated/intl/messages_es.dart
+++ b/lib/generated/intl/messages_es.dart
@@ -38,6 +38,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m8(w) => "Peso ${w} g";
 
+  static String m9(temp) => "Temperatura de agua ${temp} °C";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "beans": MessageLookupByLibrary.simpleMessage("Frijoles"),
@@ -505,6 +507,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "screenSteamTwotapMode":
             MessageLookupByLibrary.simpleMessage("Modo Steam de dos toques:"),
         "screenWaterWeightG": m8,
+        "screenHotWaterTemperaturs": m9,
         "settings": MessageLookupByLibrary.simpleMessage("Ajustes"),
         "show": MessageLookupByLibrary.simpleMessage("Espectáculo"),
         "start": MessageLookupByLibrary.simpleMessage("Comenzar"),

--- a/lib/generated/intl/messages_ko.dart
+++ b/lib/generated/intl/messages_ko.dart
@@ -38,6 +38,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m8(w) => "무게 ${w}g";
 
+  static String m9(temp) => "수온 ${temp} °C";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "beans": MessageLookupByLibrary.simpleMessage("원두"),
@@ -443,6 +445,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "screenSteamTwotapMode":
             MessageLookupByLibrary.simpleMessage("Steam 투탭 모드:"),
         "screenWaterWeightG": m8,
+        "screenHotWaterTemperaturs": m9,
         "settings": MessageLookupByLibrary.simpleMessage("설정"),
         "show": MessageLookupByLibrary.simpleMessage("보여주다"),
         "start": MessageLookupByLibrary.simpleMessage("시작"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -2345,6 +2345,15 @@ class S {
       args: [temp],
     );
   }
+  /// `Water Temperaturs {temp} °C`
+  String screenHotWaterTemperaturs(Object temp) {
+    return Intl.message(
+      'Water Temperaturs $temp °C',
+      name: 'screenHotWaterTemperaturs',
+      desc: '',
+      args: [temp],
+    );
+  }
 
   /// `Temp Tip`
   String get screenSteamTempTip {

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -468,6 +468,8 @@
   "@screenSteamTwotapMode": {},
   "screenWaterWeightG": "الوزن {w} ز",
   "@screenWaterWeightG": {},
+  "screenHotWaterTemperaturs": "درجة حرارة الماء {temp} °C",
+  "@screenHotWaterTemperaturs": {},
   "settings": "إعدادات",
   "@settings": {},
   "show": "يعرض",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -468,6 +468,8 @@
   "@screenSteamTwotapMode": {},
   "screenWaterWeightG": "Gewicht {w} g",
   "@screenWaterWeightG": {},
+  "screenHotWaterTemperaturs": "Wasser Temperatur {temp} °C",
+  "@screenHotWaterTemperaturs": {},
   "settings": "Einstellungen",
   "@settings": {},
   "show": "Anzeigen",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -468,6 +468,8 @@
   "@screenSteamTwotapMode": {},
   "screenWaterWeightG": "Weight {w} g",
   "@screenWaterWeightG": {},
+  "screenHotWaterTemperaturs": "Water Temperature {temp} °C",
+  "@screenHotWaterTemperaturs": {},
   "settings": "Settings",
   "@settings": {},
   "show": "Show",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -468,6 +468,8 @@
   "@screenSteamTwotapMode": {},
   "screenWaterWeightG": "Peso {w} g",
   "@screenWaterWeightG": {},
+  "screenHotWaterTemperaturs": "Temperatura de agua {temp} °C",
+  "@screenHotWaterTemperaturs": {},
   "settings": "Ajustes",
   "@settings": {},
   "show": "Espectáculo",

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -468,6 +468,8 @@
   "@screenSteamTwotapMode": {},
   "screenWaterWeightG": "무게 {w}g",
   "@screenWaterWeightG": {},
+  "screenHotWaterTemperaturs": "수온 {temp} °C",
+  "@screenHotWaterTemperaturs": {},
   "settings": "설정",
   "@settings": {},
   "show": "보여주다",

--- a/lib/ui/screens/water_screen.dart
+++ b/lib/ui/screens/water_screen.dart
@@ -63,7 +63,7 @@ class WaterScreenState extends State<WaterScreen> {
                       flex: 1,
                       child: Column(
                         children: [
-                          Text(S.of(context).screenSteamTemperaturs(settings.targetHotWaterTemp),
+                          Text(S.of(context).screenHotWaterTemperaturs(settings.targetHotWaterTemp),
                               style: Theme.of(context).textTheme.labelLarge),
                           Slider(
                             value: settings.targetHotWaterTemp.toDouble(),


### PR DESCRIPTION
Hi guys,

just a quick fix regarding the title of "hot water" on the water page.
Used to be "steam temperatures" but should be "water temperature" I guess.

Due to some I10n dependency imcompatibilities I was not able to pub get, so please check the code again before merging.
Oh and my Korean and Arabic skills are zero, so the translations are kindly provided by google thus might be incorrect as well 🤷‍♂️ 

Thx for your effort! I really appreciate your work!