### PR TITLE
Rework wakelock implementation.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,6 @@ import 'helper/objectbox_cache_provider.dart';
 import 'logger_util.dart';
 import 'objectbox.dart';
 import 'ui/landingpage.dart';
-import 'package:wakelock_plus/wakelock_plus.dart';
 import 'color_schemes.g.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -37,11 +36,6 @@ Future<void> main() async {
   objectbox = await ObjectBox.create();
   getIt.registerSingleton<ObjectBox>(objectbox, signalsReady: false);
   log.info("Starting app");
-  try {
-    WakelockPlus.enable();
-  } on MissingPluginException catch (e) {
-    log.info('Failed to set wakelock: $e');
-  }
 
   SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky, overlays: []);
 

--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -298,36 +298,16 @@ class EspressoMachineService extends ChangeNotifier {
     Timer.periodic(const Duration(seconds: 10), (timer) async {
       if (state.coffeeState == EspressoMachineState.sleep) {
         try {
-          log.fine("Machine is still sleeping $sleepTime ${settingsService.screenLockTimer * 60}");
+          log.fine("Machine is still sleeping $sleepTime");
           sleepTime += 10;
           if (sleepTime < 30 && settingsService.scaleDisplayOffOnSleep) {
             scaleService.display(DisplayMode.off);
           }
-          // if (sleepTime > settingsService.screenLockTimer * 60 && settingsService.screenLockTimer > 0.1) {
-          //   try {
-          //     if (await Wakelock.enabled) {
-          //       log.info('Disable WakeLock');
-          //       Wakelock.disable();
-          //     }
-          //   } on MissingPluginException catch (e) {
-          //     log.severe('Failed to set wakelock: $e');
-          //   }
-          // }
         } catch (e) {
           log.severe("Error $e");
         }
       } else {
         sleepTime = 0;
-        // try {
-        //   if ((await Wakelock.enabled) == false) {
-        //     log.info('enable WakeLock');
-        //     Wakelock.enable();
-        //   } else {
-        //     log.fine('is enabled WakeLock');
-        //   }
-        // } on MissingPluginException catch (e) {
-        //   log.severe('Failed to set wakelock enable: $e');
-        // }
       }
 
       if (state.coffeeState == EspressoMachineState.idle) {

--- a/lib/model/services/state/screen_saver.dart
+++ b/lib/model/services/state/screen_saver.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:despresso/model/services/ble/machine_service.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:screen_brightness/screen_brightness.dart';
 import 'package:despresso/model/services/state/settings_service.dart';
@@ -34,9 +33,11 @@ class ScreensaverService extends ChangeNotifier {
     notifyListeners();
 
 // Prevent screensave to go online during a pour.
-    machine.streamState.listen((event) {
+    machine.streamState.listen((event) async {
       if (event.state != lastState) {
         lastState = event.state;
+        await setWakelock();
+
         switch (lastState) {
           case EspressoMachineState.idle:
             resume();
@@ -76,43 +77,59 @@ class ScreensaverService extends ChangeNotifier {
     );
   }
 
-  bool allwaysWakeLock() {
-    return _settings.screenLockTimer > 239;
+  bool shouldBeWakelocked() {
+    if (_settings.tabletSleepDuringScreensaver && screenSaverOn) {
+      if (_screenSaverTimer >= _settings.tabletSleepDuringScreensaverTimeout * 60) {
+        return false;
+      }
+    }
+
+    if (_settings.tabletSleepWhenMachineOff) {
+      switch (lastState) {
+        case EspressoMachineState.connecting:
+        case EspressoMachineState.disconnected:
+        case EspressoMachineState.sleep:
+          return false;
+        case EspressoMachineState.espresso:
+        case EspressoMachineState.flush:
+        case EspressoMachineState.idle:
+        case EspressoMachineState.refill:
+        case EspressoMachineState.steam:
+        case EspressoMachineState.water:
+          break;
+      }
+    }
+
+    return true;
   }
 
-  bool useWakeLock() {
-    return _settings.screenLockTimer > 0;
-  }
+  Future<void> setWakelock() async {
+    var isLocked = await WakelockPlus.enabled;
+    var shouldBeLocked = shouldBeWakelocked();
 
-  void setupScreensaver() {
     try {
-      if (useWakeLock()) {
+      if (!isLocked && shouldBeLocked) {
         WakelockPlus.enable();
-        log.info('Enable WakeLock');
-      } else {
+      } else if (isLocked && !shouldBeLocked) {
         WakelockPlus.disable();
       }
     } catch (e) {
-      log.severe("Could not use WakeLock $e");
+      log.severe("Failed to set wakelock: $e");
     }
+  }
+
+  void setupScreensaver() {
+    setWakelock();
 
     _timer = Timer.periodic(
       const Duration(seconds: 5),
       (timer) async {
+        await setWakelock();
+
         if (_paused == true) return;
         _screenSaverTimer += 5;
         // log.fine("Tick  $_screenSaverTimer ${_settings.screenBrightnessTimer * 60} on: $screenSaverOn");
         await checkAndActivateSaver();
-        if (_screenSaverTimer > _settings.screenLockTimer * 60 && !allwaysWakeLock()) {
-          try {
-            if (await WakelockPlus.enabled) {
-              log.info('Disable WakeLock');
-              WakelockPlus.disable();
-            }
-          } on MissingPluginException catch (e) {
-            log.severe('Failed to set wakelock: $e');
-          }
-        }
       },
     );
   }
@@ -140,19 +157,10 @@ class ScreensaverService extends ChangeNotifier {
     if (screenSaverOn) {
       screenSaverOn = false;
       ScreenBrightness().resetScreenBrightness();
+      setWakelock();
 
       if (_settings.screenTapWake) {
         machine.de1?.switchOn();
-      }
-      try {
-        if ((await WakelockPlus.enabled) == false) {
-          log.info('enable WakeLock');
-          WakelockPlus.enable();
-        } else {
-          log.fine('is enabled WakeLock');
-        }
-      } on MissingPluginException catch (e) {
-        log.severe('Failed to set wakelock enable: $e');
       }
       notifyListeners();
     }

--- a/lib/model/services/state/settings_service.dart
+++ b/lib/model/services/state/settings_service.dart
@@ -15,7 +15,6 @@ enum SettingKeys {
   visualizerUser,
   visualizerPwd,
   sleepTimer,
-  screenLockTimer,
   graphSingle,
   mqttEnabled,
   mqttServer,
@@ -92,6 +91,9 @@ enum SettingKeys {
   targetMilkTempPreset1,
   targetMilkTempPreset2,
   targetMilkTempPreset3,
+  tabletSleepDuringScreensaver,
+  tabletSleepDuringScreensaverTimeout,
+  tabletSleepWhenMachineOff,
 }
 
 class SettingsService extends ChangeNotifier {
@@ -130,7 +132,9 @@ class SettingsService extends ChangeNotifier {
   String get visualizerPwd => Settings.getValue(SettingKeys.visualizerPwd.name) ?? "";
 
   double get sleepTimer => Settings.getValue<double>(SettingKeys.sleepTimer.name) ?? 15;
-  double get screenLockTimer => Settings.getValue<double>(SettingKeys.screenLockTimer.name) ?? 30;
+  bool get tabletSleepDuringScreensaver => Settings.getValue<bool>(SettingKeys.tabletSleepDuringScreensaver.name) ?? false;
+  double get tabletSleepDuringScreensaverTimeout => Settings.getValue<double>(SettingKeys.tabletSleepDuringScreensaverTimeout.name) ?? 60;
+  bool get tabletSleepWhenMachineOff => Settings.getValue<bool>(SettingKeys.tabletSleepWhenMachineOff.name) ?? false;
 
   bool get mqttEnabled => Settings.getValue<bool>(SettingKeys.mqttEnabled.name) ?? false;
   String get mqttServer => Settings.getValue<String>(SettingKeys.mqttServer.name) ?? "192.168.178.79";

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -684,19 +684,36 @@ class SettingsScreenState extends State<AppSettingsScreen> {
                     ),
                   ],
                 ),
-                SliderSettingsTile(
-                  title: S.of(context).screenSettingsDoNotLetTabletGoToLockScreen0doNot,
-                  // subtitle: settingsService.screenLockTimer > 239 ? "Switched off" : "bla",
-                  settingKey: SettingKeys.screenLockTimer.name,
-                  defaultValue: settingsService.screenLockTimer,
-                  min: 0,
-                  max: 240,
-                  step: 5,
-                  leading: const Icon(Icons.lock),
-                  onChange: (value) {
-                    setState(() {});
-                  },
-                )
+                SettingsGroup(
+                  title: "Tablet sleep",
+                  children: [
+                    SwitchSettingsTile(
+                      title: "Allow tablet sleep during screensaver",
+                      settingKey: SettingKeys.tabletSleepDuringScreensaver.name,
+                      defaultValue: settingsService.tabletSleepDuringScreensaver,
+                      childrenIfEnabled: [
+                        SliderSettingsTile(
+                          title: "Minutes to spend in screensaver before allowing sleep",
+                          settingKey: SettingKeys.tabletSleepDuringScreensaverTimeout.name,
+                          defaultValue: settingsService.tabletSleepDuringScreensaverTimeout,
+                          min: 0,
+                          max: 240,
+                          step: 5,
+                          decimalPrecision: 0,
+                        ),
+                      ],
+                    ),
+                    SwitchSettingsTile(
+                      title: "Allow tablet sleep when machine is sleeping or disconnected",
+                      settingKey: SettingKeys.tabletSleepWhenMachineOff.name,
+                      defaultValue: settingsService.tabletSleepWhenMachineOff,
+                    ),
+                    const Padding(
+                      padding: EdgeInsets.only(top: 16, bottom: 32, left: 16, right: 16),
+                      child: Text("Warning: depending on your tablet and operating system settings, letting your tablet go to sleep might cause interruptions to the Bluetooth connection to your machine or accessories."),
+                    )
+                  ]
+                ),
               ]),
             ),
             SimpleSettingsTile(


### PR DESCRIPTION
This is what @obiwan007 and I talked about on Discord. The background: on my Android tablet, I have disabled the lockscreen (i.e. I can just press the power button, no lock pattern or swipe or anything needed), and I've set the screen timeout to 15s. I'm doing this because I want to screen to be **off** whenever I don't need it - because even on the lowest brightness and with a fully black screen, the tablet is bright enough to illuminate my kitchen and parts of the hallway. :)

This PR reworks the entire wakelock implementation to be a bit more understandable, less fragmented, and to improve UX. It has essentially two parts.

The first part is a rework of the old feature to provide a better UX. Previously, there was only one slider, with the label "Do not let tablet go to lock screen (0=do not lock screen, 240=keep always locked) [min]". This is actively misleading. The "lock screen" in the brackets here means "enable the wakelock". So you'd have to set the slider to 240 to always keep the screen awake - which is the exact opposite what I'd expect. I also generally dislike slider with "magic values" that somehow behave differently than the other values. This PR replaces this with a two-part UI. The first part is a boolean switch with the clear label "Allow tablet sleep during screensaver". If - and only if - this switch is enabled, a time-slider "Minutes to spend in screensaver before allowing sleep" is visible. This is the same 0-240 minute range that does exactly what the slider previously did - but no more "magic value".

The second part is the addition of the "Allow tablet sleep when machine is sleeping or disconnected" switch. This does exactly what it says it does. If the machine is asleep (or not connected), the tablet will be allowed to sleep. If the machine is awake, it will be wakelocked. This behavior is also available in de1app behind a hidden setting `lock_screen_during_screensaver` and I've been using it for a while. The motivation for that is that I do not want to have a screensaver or anything if the machine is *on*. I just want the UI to be visible if the machine is on. However, if the machine is off, I want to display to turn off, for the reasons I outlined earlier. I did run this for a couple of days now, and it works fine for me.

Since @obiwan007 mentioned on Discord that letting the tablet go to sleep can introduce connection issues, I've made an attempt at preventing accidents. The default values for this implementation is to never allow the tablet to sleep - so the user has to actively opt-in into that. Additionally, I've placed a warning close to the wakelock settings, so that the users are aware that if they choose to let their tablet go to sleep, it might cause issues.

[This is a screenshot](https://github.com/obiwan007/despresso/assets/344777/c2ae77ea-a295-400d-aa05-8836448b16f4) of what this looks like - in this case, the timer-based sleep is enabled so that the slider is visible.

Two technical notes for this PR:

- This PR introduces new strings that are not translateable. I wanted to make them translateable, and added strings to `lib/l10n/intl_en.arb` - but `flutter gen-l10n` did not update the auto-generated files in `lib/generated/`. Since I have no idea how to update those auto-generated files, I've decided to have my string join the already existing myriad of untranslateable strings.
- Likewise, I have removed the usage of the string `screenSettingsDoNotLetTabletGoToLockScreen0doNot`, but did not remove the definitions and translations. Same reason.


