### PR TITLE
[WIP] "Move on at weight" support

### DIFF
--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1976,6 +1976,16 @@ class S {
     );
   }
 
+  /// `Stop before step "move on at weight" reached [s]`
+  String get screenSettingsStopBeforeStepWeightWasReachedS {
+    return Intl.message(
+      'Stop before step weight limit is reached [s]',
+      name: 'screenSettingsStopBeforeStepWeightWasReachedS',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Stop on Weight if scale detected`
   String get screenSettingsStopOnWeightIfScaleDetected {
     return Intl.message(

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1976,16 +1976,6 @@ class S {
     );
   }
 
-  /// `Stop before step "move on at weight" reached [s]`
-  String get screenSettingsStopBeforeStepWeightWasReachedS {
-    return Intl.message(
-      'Stop before step weight limit is reached [s]',
-      name: 'screenSettingsStopBeforeStepWeightWasReachedS',
-      desc: '',
-      args: [],
-    );
-  }
-
   /// `Stop on Weight if scale detected`
   String get screenSettingsStopOnWeightIfScaleDetected {
     return Intl.message(

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -383,7 +383,7 @@
   "screenSettingsSpecialBluetoothDevices": "Special Bluetooth devices",
   "@screenSettingsSpecialBluetoothDevices": {},
   "screenSettingsStopBeforeWeightWasReachedS": "Stop before weight was reached [s]",
-  "@screenSettingsStopBeforeWeightWasReachedS": {},
+  "@screenSettingsStopBeforeWeightWasReachedS": 'Offset move-on-at-weight delay [s]',
   "screenSettingsStopOnWeightIfScaleDetected": "Stop on Weight if scale detected",
   "@screenSettingsStopOnWeightIfScaleDetected": {},
   "screenSettingsSwitchDe1ToSleepModeIfItIsIdleFor": "Switch de1 to sleep mode if it is idle for some time [min]",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -383,7 +383,7 @@
   "screenSettingsSpecialBluetoothDevices": "Special Bluetooth devices",
   "@screenSettingsSpecialBluetoothDevices": {},
   "screenSettingsStopBeforeWeightWasReachedS": "Stop before weight was reached [s]",
-  "@screenSettingsStopBeforeWeightWasReachedS": 'Offset move-on-at-weight delay [s]',
+  "@screenSettingsStopBeforeWeightWasReachedS": {},
   "screenSettingsStopOnWeightIfScaleDetected": "Stop on Weight if scale detected",
   "@screenSettingsStopOnWeightIfScaleDetected": {},
   "screenSettingsSwitchDe1ToSleepModeIfItIsIdleFor": "Switch de1 to sleep mode if it is idle for some time [min]",

--- a/lib/model/de1shotclasses.dart
+++ b/lib/model/de1shotclasses.dart
@@ -238,6 +238,7 @@ class De1ShotFrameClass // proc spec_shotframe
   double frameLen = 0.0; // convert_F8_1_7_to_float
   double triggerVal = 0; // {
   double maxVol = 0.0; // convert_bottom_10_of_U10P0
+  double maxWeight = 0.0;
   String name = "";
   String pump = "";
   String sensor = "";
@@ -282,6 +283,7 @@ class De1ShotFrameClass // proc spec_shotframe
     copy.temp = temp;
     copy.transition = transition;
     copy.triggerVal = triggerVal;
+    copy.maxWeight = maxWeight;
 
     return copy;
   }

--- a/lib/model/de1shotclasses.g.dart
+++ b/lib/model/de1shotclasses.g.dart
@@ -85,6 +85,7 @@ De1ShotFrameClass _$De1ShotFrameClassFromJson(Map<String, dynamic> json) =>
       ..frameLen = (json['frameLen'] as num).toDouble()
       ..triggerVal = (json['triggerVal'] as num).toDouble()
       ..maxVol = (json['maxVol'] as num).toDouble()
+      ..maxWeight = (json['maxWeight'] as num).toDouble()
       ..name = json['name'] as String
       ..pump = json['pump'] as String
       ..sensor = json['sensor'] as String
@@ -100,6 +101,7 @@ Map<String, dynamic> _$De1ShotFrameClassToJson(De1ShotFrameClass instance) =>
       'frameLen': instance.frameLen,
       'triggerVal': instance.triggerVal,
       'maxVol': instance.maxVol,
+      'maxWeight': instance.maxWeight,
       'name': instance.name,
       'pump': instance.pump,
       'sensor': instance.sensor,

--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -221,6 +221,7 @@ class EspressoMachineService extends ChangeNotifier {
   final List<int> _waterAverager = [];
 
   bool _delayedStopActive = false;
+  int? _delayedMoveOnFrame;
 
   int flushCounter = 0;
   DateTime lastFlushTime = DateTime.now();
@@ -582,6 +583,7 @@ class EspressoMachineService extends ChangeNotifier {
       currentShot.targetEspressoWeight = settingsService.targetEspressoWeight;
 
       _delayedStopActive = false;
+      _delayedMoveOnFrame = null;
       isPouring = false;
       shotList.clear();
       baseTime = DateTime.now().millisecondsSinceEpoch / 1000.0;
@@ -729,18 +731,66 @@ class EspressoMachineService extends ChangeNotifier {
             }
           }
 
+          // move-on-at-weight logic
+          // N.B. I tried using linear regression like we do for stop-at-weight
+          // but got really poor results. Probably due to the small amount of
+          // data we have to work with when doing weight-based fill steps etc.
+          // This instead does exponential smoothing over the past ~1s of flow
+          // weight readings.
           if (scaleService.state[0] == ScaleState.connected) {
-            var frame = profileService.currentProfile?.shotFrames[shot.frameNumber];
-            //var stepWeightLimit = state.shotFrame?.maxWeight ?? 0.0;
+            // log.info("weight ${shot.weight}g");
+
+            // if a delayed skip is in progress, start checking for the next one
+            var frameNumberAtMoveOnCalc = _delayedMoveOnFrame != null
+                ? _delayedMoveOnFrame! + 1
+                : shot.frameNumber;
+
+            var frame = profileService
+                .currentProfile?.shotFrames[frameNumberAtMoveOnCalc];
             var stepWeightLimit = frame?.maxWeight ?? 0.0;
-            log.info("frame ${frame?.name}");
-              log.info("step weight: $stepWeightLimit, current weight: ${shot.weight}");
-            if (isPouring &&
+            var flowRate = getSmoothedFlowRate(shot, 5);
+
+            // check if we should skip soon if
+            // - we haven't already queued a skip (or stop)
+            // - water is coming out of the group, even if we're still in
+            //   pre-infusion
+            // - this frame has a weight limit
+            // - and stuff is landing on the scale
+            if (_delayedMoveOnFrame == null &&
+                (isPouring || state.subState == "pre_infuse") &&
                 stepWeightLimit > 0.0 &&
+                flowRate > 0.2 &&
                 _delayedStopActive == false) {
-              if (shot.weight >= stepWeightLimit) {
-                log.info("MOVING ON!");
-                moveToNextFrame();
+              // log.info("flow ${shot.flowWeight}, avg flow $flowRate");
+
+              var timeToWeight = (stepWeightLimit - shot.weight) / flowRate;
+              // log.info("time to weight ${timeToWeight}s");
+
+              if (timeToWeight > 0 && timeToWeight < 1.5) {
+                log.info(
+                    "Frame weight reached soon, starting delayed move on at ${shot.weight}g in ${timeToWeight}s");
+
+                _delayedMoveOnFrame = frameNumberAtMoveOnCalc;
+
+                Future.delayed(
+                  Duration(
+                      milliseconds: ((timeToWeight -
+                                  settingsService
+                                      .targetEspressoWeightTimeAdjust) *
+                              1000)
+                          .toInt()),
+                  () {
+                    if (state.shot!.frameNumber != frameNumberAtMoveOnCalc) {
+                      // some other frame skip was triggered, don't skip twice
+                      return;
+                    }
+
+                    log.info(
+                        "Frame weight reached now!, moving on ${state.shot!.weight}");
+                    _delayedMoveOnFrame = null;
+                    moveToNextFrame();
+                  },
+                );
               }
             }
           }
@@ -1035,6 +1085,15 @@ class EspressoMachineService extends ChangeNotifier {
     } else {
       return 0;
     }
+  }
+
+  double getSmoothedFlowRate(ShotState currentShot, int framesToAvg) {
+    var smoothingFactor = 0.2;
+    var startIdx = max(0, shotList.entries.length - framesToAvg + 1);
+    var flowWeights = shotList.entries.sublist(startIdx).map((shot) => shot.flowWeight).toList();
+    flowWeights.add(currentShot.flowWeight);
+    log.info("asked for $framesToAvg got ${flowWeights.length}");
+    return flowWeights.reduce((value, flow) => smoothingFactor * flow + (1 - smoothingFactor) * flow);
   }
 
   void notify() {

--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -738,7 +738,7 @@ class EspressoMachineService extends ChangeNotifier {
           // This instead does exponential smoothing over the past ~1s of flow
           // weight readings.
           if (scaleService.state[0] == ScaleState.connected) {
-            // log.info("weight ${shot.weight}g");
+            log.info("weight ${shot.weight}g");
 
             // if a delayed skip is in progress, start checking for the next one
             var frameNumberAtMoveOnCalc = _delayedMoveOnFrame != null
@@ -755,18 +755,18 @@ class EspressoMachineService extends ChangeNotifier {
             // - water is coming out of the group, even if we're still in
             //   pre-infusion
             // - this frame has a weight limit
-            // - and stuff is landing on the scale
+            // - and some fluid has come out of the portafilter
             if (_delayedMoveOnFrame == null &&
                 (isPouring || state.subState == "pre_infuse") &&
                 stepWeightLimit > 0.0 &&
-                flowRate > 0.2 &&
+                shot.weight > 0.0 &&
                 _delayedStopActive == false) {
-              // log.info("flow ${shot.flowWeight}, avg flow $flowRate");
+              log.info("flow ${shot.flowWeight}, avg flow $flowRate");
 
               var timeToWeight = (stepWeightLimit - shot.weight) / flowRate;
-              // log.info("time to weight ${timeToWeight}s");
+              log.info("time to weight ${timeToWeight}s");
 
-              if (timeToWeight > 0 && timeToWeight < 1.5) {
+              if (timeToWeight > 0 && timeToWeight < 1.0) {
                 log.info(
                     "Frame weight reached soon, starting delayed move on at ${shot.weight}g in ${timeToWeight}s");
 
@@ -774,9 +774,9 @@ class EspressoMachineService extends ChangeNotifier {
 
                 Future.delayed(
                   Duration(
-                      milliseconds: ((timeToWeight -
+                      milliseconds: (max(0, timeToWeight -
                                   settingsService
-                                      .targetEspressoWeightTimeAdjust) *
+                                      .stepLimitWeightTimeAdjust) *
                               1000)
                           .toInt()),
                   () {

--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -740,11 +740,7 @@ class EspressoMachineService extends ChangeNotifier {
           if (scaleService.state[0] == ScaleState.connected) {
             log.info("weight ${shot.weight}g");
 
-            // if a delayed skip is in progress, start checking for the next one
-            var frameNumberAtMoveOnCalc = _delayedMoveOnFrame != null
-                ? _delayedMoveOnFrame! + 1
-                : shot.frameNumber;
-
+            var frameNumberAtMoveOnCalc = shot.frameNumber;
             var frame = profileService
                 .currentProfile?.shotFrames[frameNumberAtMoveOnCalc];
             var stepWeightLimit = frame?.maxWeight ?? 0.0;
@@ -762,8 +758,8 @@ class EspressoMachineService extends ChangeNotifier {
                 stepWeightLimit > 0.0 &&
                 shot.weight > 0.0 &&
                 _delayedStopActive == false) {
-              var flowRate = getSmoothedFlowRate(shot, 5);
-              log.info("flow ${shot.flowWeight}, avg flow $flowRate");
+              var flowRate = getFlowRateForecast(shot, 1.0);
+              log.info("flow ${shot.flowWeight}, flow rate forecast $flowRate");
 
               var timeToWeight = (stepWeightLimit - shot.weight) / flowRate;
               log.info("time to weight ${timeToWeight}s");
@@ -772,8 +768,6 @@ class EspressoMachineService extends ChangeNotifier {
               if (timeToWeight > -1.0 && timeToWeight < 1.0) {
                 log.info(
                     "Frame weight reached soon, starting delayed move on at ${shot.weight}g in ${timeToWeight}s");
-
-                _delayedMoveOnFrame = frameNumberAtMoveOnCalc;
 
               var userAdjustedTimeToWeight = timeToWeight +
                                   settingsService
@@ -1092,37 +1086,131 @@ class EspressoMachineService extends ChangeNotifier {
     }
   }
 
-  // Get exponentially-smoothed flow rate over given period
-  // note this doesn't use flowWeight since the scale service averages flow
+  // Linear interpolation
+  // xpNew: the new x-coordinates to interpolate values to
+  // xp: x-coordinates of the original data
+  // fp: y-coordinates of the original data
+  List<double> interp(List<double> xpNew, List<double> xp, List<double> fp) {
+    if (xp.length != fp.length) {
+      throw ArgumentError(
+          "Input lists 'xp' and 'fp' must have the same length.");
+    }
+
+    List<double> results = [];
+
+    for (int i = 0; i < xpNew.length; i++) {
+      double x = xpNew[i];
+
+      int j = 0;
+      while (j < xp.length - 1 && xp[j + 1] <= x) {
+        j++;
+      }
+
+      double x0 = xp[j];
+      double x1 = xp[j + 1];
+      double f0 = fp[j];
+      double f1 = fp[j + 1];
+
+      double interpolatedValue = f0 + (f1 - f0) * (x - x0) / (x1 - x0);
+      results.add(interpolatedValue);
+    }
+
+    return results;
+  }
+
+  // Double exponential smoothing over the given data. Data points are assumed
+  // to have equal temporal spacing. Returns the values of s, b at each point.
+  List<List<double>> doubleExponentialSmoothing(List<double> input,
+      double dataSmoothingFactor, double trendSmoothingFactor) {
+    var s = input[0];
+    var b = input[1] - input[0];
+
+    List<List<double>> result = [[s, b]];
+
+    input.sublist(1).forEach((x) {
+      var s_1 = s;
+      var b_1 = b;
+      s = x * dataSmoothingFactor + (1 - dataSmoothingFactor) * (s_1 + b_1);
+      b = trendSmoothingFactor * (s - s_1) + (1 - trendSmoothingFactor) * b_1;
+      result.add([s, b]);
+    });
+
+    return result;
+  }
+
+  // Get flow rate forecast using double exponential smoothing.
+  // note we don't use flowWeight since the scale service averages flow
   // over 10 readings, which results in too-small flow values at the start of
   // the shot.
-  double getSmoothedFlowRate(ShotState currentShot, int framesToAvg) {
-    // gather shot states
-    var startIdx = max(0, shotList.entries.length - framesToAvg + 1);
-    var shotStates = shotList.entries.sublist(startIdx);
-    shotStates.add(currentShot);
+  double getFlowRateForecast(
+      ShotState currentShot, double sampleWindowSeconds) {
+    var sampleStartTime = currentShot.sampleTime - sampleWindowSeconds;
+    var samplesStartIndex = shotList.entries.length - 1;
+    List<ShotState> samples = [currentShot];
 
-    if (shotStates.length < 2) {
+    // iterate backwards through shots until we find the start of the window
+    while (samplesStartIndex >= 0 &&
+        shotList.entries[samplesStartIndex].sampleTime > sampleStartTime) {
+      if (!shotList.entries[samplesStartIndex].isInterpolated) {
+        samples.add(shotList.entries[samplesStartIndex]);
+      }
+
+      samplesStartIndex--;
+    }
+
+    if (samples.isEmpty) {
       return 0.0;
     }
 
-    // calculate flow rates
-    // TODO records would be better here but need to enable support
-    var flowRates = List.generate(shotStates.length - 1,
-            (index) => [shotStates[index], shotStates[index + 1]])
-        .map((pair) =>
-            (pair[1].weight - pair[0].weight) /
-            (pair[1].sampleTime - pair[0].sampleTime))
-        // TODO: occasionally +-Infinity comes up
-        // why are there shot states with identical sample times?
-        .where((flowRate) => flowRate.isFinite)
-        .toList();
+    if (samples.length == 1) {
+      return samples[0].flowWeight;
+    }
 
-    log.info("flow rate samples $flowRates");
+    // samples are in reverse order at the moment
+    var selectedSamples = samples.reversed;
 
-    var smoothingFactor = 0.2;
-    return flowRates.reduce(
-        (value, flow) => smoothingFactor * flow + (1 - smoothingFactor) * value);
+    var selectedSampleWeights =
+        selectedSamples.map((shot) => shot.weight).toList();
+    var selectedSampleTimes =
+        selectedSamples.map((shot) => shot.sampleTime).toList();
+
+    // this will probably be slightly different than the requested sample window
+    var actualSampleWindow = samples.first.sampleTime - samples.last.sampleTime;
+
+    // get a list of equally spaced sample times between the start and end
+    // of the sample window
+    var timestep = actualSampleWindow / samples.length;
+    var interpolatedSampleTimes =
+        List.generate(samples.length, (i) => i * timestep + samples.last.sampleTime);
+
+    var interpolatedSampleWeights = interp(
+        interpolatedSampleTimes, selectedSampleTimes, selectedSampleWeights);
+
+    // These values for data smoothing, trend smoothing factors were found by
+    // minimizing square error of forecast weights on real shot data
+    var smoothed = doubleExponentialSmoothing(interpolatedSampleWeights, 0.6, 0.5);
+
+    // double exponential forecast is given by adding b * m to the last smoothed
+    // value, where "m" is a discrete number of time steps.
+    // Therefore the gradient is b divided by the time step size
+    // (and weight gradient == flow rate)
+    var b = smoothed.last[1];
+    var gradient = b / timestep;
+
+    // multiplying by the ratio of current : previous flow rate slightly
+    // improves fit IME, using b alone under-estimates increase/decreases in
+    // flow rate
+    var b_2 = smoothed[smoothed.length - 2][1];
+    var fudgeFactor = b / b_2;
+    fudgeFactor = fudgeFactor.isFinite ? fudgeFactor : 1;
+
+    log.info("weight samples $selectedSampleWeights");
+    log.info("time samples $selectedSampleTimes");
+    log.info("interpolated weight samples $interpolatedSampleWeights");
+    log.info("interpolated time samples $interpolatedSampleTimes");
+    log.info("exp smooth result $smoothed");
+
+    return gradient * fudgeFactor;
   }
 
   void notify() {

--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -748,7 +748,8 @@ class EspressoMachineService extends ChangeNotifier {
             var frame = profileService
                 .currentProfile?.shotFrames[frameNumberAtMoveOnCalc];
             var stepWeightLimit = frame?.maxWeight ?? 0.0;
-            var flowRate = getSmoothedFlowRate(shot, 5);
+
+            log.info("DEBUG $_delayedMoveOnFrame $isPouring $stepWeightLimit ${shot.weight} $_delayedStopActive");
 
             // check if we should skip soon if
             // - we haven't already queued a skip (or stop)
@@ -761,22 +762,26 @@ class EspressoMachineService extends ChangeNotifier {
                 stepWeightLimit > 0.0 &&
                 shot.weight > 0.0 &&
                 _delayedStopActive == false) {
+              var flowRate = getSmoothedFlowRate(shot, 5);
               log.info("flow ${shot.flowWeight}, avg flow $flowRate");
 
               var timeToWeight = (stepWeightLimit - shot.weight) / flowRate;
               log.info("time to weight ${timeToWeight}s");
 
-              if (timeToWeight > 0 && timeToWeight < 1.0) {
+              // allow small negative values in case we just missed our chance
+              if (timeToWeight > -1.0 && timeToWeight < 1.0) {
                 log.info(
                     "Frame weight reached soon, starting delayed move on at ${shot.weight}g in ${timeToWeight}s");
 
                 _delayedMoveOnFrame = frameNumberAtMoveOnCalc;
 
+              var userAdjustedTimeToWeight = timeToWeight +
+                                  settingsService
+                                      .stepLimitWeightTimeAdjust;
+
                 Future.delayed(
                   Duration(
-                      milliseconds: (max(0, timeToWeight -
-                                  settingsService
-                                      .stepLimitWeightTimeAdjust) *
+                      milliseconds: (max(0, userAdjustedTimeToWeight ) *
                               1000)
                           .toInt()),
                   () {
@@ -1087,13 +1092,37 @@ class EspressoMachineService extends ChangeNotifier {
     }
   }
 
+  // Get exponentially-smoothed flow rate over given period
+  // note this doesn't use flowWeight since the scale service averages flow
+  // over 10 readings, which results in too-small flow values at the start of
+  // the shot.
   double getSmoothedFlowRate(ShotState currentShot, int framesToAvg) {
-    var smoothingFactor = 0.2;
+    // gather shot states
     var startIdx = max(0, shotList.entries.length - framesToAvg + 1);
-    var flowWeights = shotList.entries.sublist(startIdx).map((shot) => shot.flowWeight).toList();
-    flowWeights.add(currentShot.flowWeight);
-    log.info("asked for $framesToAvg got ${flowWeights.length}");
-    return flowWeights.reduce((value, flow) => smoothingFactor * flow + (1 - smoothingFactor) * flow);
+    var shotStates = shotList.entries.sublist(startIdx);
+    shotStates.add(currentShot);
+
+    if (shotStates.length < 2) {
+      return 0.0;
+    }
+
+    // calculate flow rates
+    // TODO records would be better here but need to enable support
+    var flowRates = List.generate(shotStates.length - 1,
+            (index) => [shotStates[index], shotStates[index + 1]])
+        .map((pair) =>
+            (pair[1].weight - pair[0].weight) /
+            (pair[1].sampleTime - pair[0].sampleTime))
+        // TODO: occasionally +-Infinity comes up
+        // why are there shot states with identical sample times?
+        .where((flowRate) => flowRate.isFinite)
+        .toList();
+
+    log.info("flow rate samples $flowRates");
+
+    var smoothingFactor = 0.2;
+    return flowRates.reduce(
+        (value, flow) => smoothingFactor * flow + (1 - smoothingFactor) * value);
   }
 
   void notify() {
@@ -1118,7 +1147,7 @@ class LineEq {
 
   getY(double x) {
     double y = (m) * (x - x1) + b;
-    log.info("lin: $y = ($m * $x + $b");
+    // log.info("lin: $y = ($m * $x + $b");
     return y;
   }
 }

--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -101,6 +101,13 @@ const waterMap = [
   2058,
 ];
 
+class TimedWeightMeasurement {
+  TimedWeightMeasurement(this.weight, this.time);
+
+  WeightMeassurement weight;
+  double time;
+}
+
 class WaterLevel {
   WaterLevel(this.waterLevel, this.waterLimit);
 
@@ -184,6 +191,11 @@ class EspressoMachineService extends ChangeNotifier {
   late CoffeeService coffeeService;
   late SettingsService settingsService;
 
+  // Keeps track of events from ScaleService (cleared at start of shot).
+  // Useful if you need weight samples that aren't quantized to ShotList
+  // elements
+  List<TimedWeightMeasurement> weightMeasurementsDuringShot = [];
+
   ShotList shotList = ShotList([]);
   double baseTime = 0;
 
@@ -221,7 +233,7 @@ class EspressoMachineService extends ChangeNotifier {
   final List<int> _waterAverager = [];
 
   bool _delayedStopActive = false;
-  int? _delayedMoveOnFrame;
+  Set<int> _delayedMoveOnFrames = {};
 
   int flushCounter = 0;
   DateTime lastFlushTime = DateTime.now();
@@ -282,6 +294,12 @@ class EspressoMachineService extends ChangeNotifier {
     profileService.addListener(updateProfile);
     scaleService = getIt<ScaleService>();
     coffeeService = getIt<CoffeeService>();
+
+    scaleService.stream0.listen((measurement) {
+    if (state.subState == "pour" || state.subState == "pre_infuse" || state.subState =="heat_water_heater") {
+      weightMeasurementsDuringShot.add(TimedWeightMeasurement(measurement, DateTime.now().millisecondsSinceEpoch  / 1000.0));
+      }
+    });
 
     log.fine('Preferences loaded');
 
@@ -583,9 +601,10 @@ class EspressoMachineService extends ChangeNotifier {
       currentShot.targetEspressoWeight = settingsService.targetEspressoWeight;
 
       _delayedStopActive = false;
-      _delayedMoveOnFrame = null;
+      _delayedMoveOnFrames = {};
       isPouring = false;
       shotList.clear();
+      weightMeasurementsDuringShot.clear();
       baseTime = DateTime.now().millisecondsSinceEpoch / 1000.0;
       log.info("basetime $baseTime");
       lastPourTime = 0;
@@ -745,7 +764,8 @@ class EspressoMachineService extends ChangeNotifier {
                 .currentProfile?.shotFrames[frameNumberAtMoveOnCalc];
             var stepWeightLimit = frame?.maxWeight ?? 0.0;
 
-            log.info("DEBUG $_delayedMoveOnFrame $isPouring $stepWeightLimit ${shot.weight} $_delayedStopActive");
+            log.info("DEBUG ${_delayedMoveOnFrames.contains(frameNumberAtMoveOnCalc)} $isPouring ${shot.subState} $stepWeightLimit ${shot.weight} $_delayedStopActive");
+            // log.info("listened weights ${thing.map((m) => m.weight.weight)}");
 
             // check if we should skip soon if
             // - we haven't already queued a skip (or stop)
@@ -753,21 +773,21 @@ class EspressoMachineService extends ChangeNotifier {
             //   pre-infusion
             // - this frame has a weight limit
             // - and some fluid has come out of the portafilter
-            if (_delayedMoveOnFrame == null &&
+            if (!_delayedMoveOnFrames.contains(frameNumberAtMoveOnCalc) &&
                 (isPouring || state.subState == "pre_infuse") &&
                 stepWeightLimit > 0.0 &&
                 shot.weight > 0.0 &&
                 _delayedStopActive == false) {
-              var flowRate = getFlowRateForecast(shot, 1.0);
-              log.info("flow ${shot.flowWeight}, flow rate forecast $flowRate");
-
-              var timeToWeight = (stepWeightLimit - shot.weight) / flowRate;
+              var timeToWeight = getTimeToWeightForecast(shot.sampleTime - 1.0, shot.sampleTime, stepWeightLimit);
+              log.info("flow ${shot.flowWeight}");
               log.info("time to weight ${timeToWeight}s");
 
               // allow small negative values in case we just missed our chance
               if (timeToWeight > -1.0 && timeToWeight < 1.0) {
                 log.info(
                     "Frame weight reached soon, starting delayed move on at ${shot.weight}g in ${timeToWeight}s");
+
+                _delayedMoveOnFrames.add(frameNumberAtMoveOnCalc);
 
               var userAdjustedTimeToWeight = timeToWeight +
                                   settingsService
@@ -786,7 +806,6 @@ class EspressoMachineService extends ChangeNotifier {
 
                     log.info(
                         "Frame weight reached now!, moving on ${state.shot!.weight}");
-                    _delayedMoveOnFrame = null;
                     moveToNextFrame();
                   },
                 );
@@ -1102,7 +1121,7 @@ class EspressoMachineService extends ChangeNotifier {
       double x = xpNew[i];
 
       int j = 0;
-      while (j < xp.length - 1 && xp[j + 1] <= x) {
+      while (j < xp.length - 1 && xp[j + 1] < x) {
         j++;
       }
 
@@ -1138,57 +1157,44 @@ class EspressoMachineService extends ChangeNotifier {
     return result;
   }
 
-  // Get flow rate forecast using double exponential smoothing.
-  // note we don't use flowWeight since the scale service averages flow
-  // over 10 readings, which results in too-small flow values at the start of
-  // the shot.
-  double getFlowRateForecast(
-      ShotState currentShot, double sampleWindowSeconds) {
-    var sampleStartTime = currentShot.sampleTime - sampleWindowSeconds;
-    var samplesStartIndex = shotList.entries.length - 1;
-    List<ShotState> samples = [currentShot];
-
-    // iterate backwards through shots until we find the start of the window
-    while (samplesStartIndex >= 0 &&
-        shotList.entries[samplesStartIndex].sampleTime > sampleStartTime) {
-      if (!shotList.entries[samplesStartIndex].isInterpolated) {
-        samples.add(shotList.entries[samplesStartIndex]);
-      }
-
-      samplesStartIndex--;
-    }
+  // Get remaining time to given weight using double exponential smoothing.
+  double getTimeToWeightForecast(
+      double sampleWindowStart, double sampleWindowEnd, double targetWeight) {
+    var samples = weightMeasurementsDuringShot
+        .where((m) => m.time >= sampleWindowStart && m.time <= sampleWindowEnd);
 
     if (samples.isEmpty) {
       return 0.0;
     }
 
     if (samples.length == 1) {
-      return samples[0].flowWeight;
+      return samples.first.weight.flow;
     }
 
-    // samples are in reverse order at the moment
-    var selectedSamples = samples.reversed;
-
-    var selectedSampleWeights =
-        selectedSamples.map((shot) => shot.weight).toList();
-    var selectedSampleTimes =
-        selectedSamples.map((shot) => shot.sampleTime).toList();
+    var selectedSampleWeights = samples.map((m) => m.weight.weight).toList();
+    var selectedSampleTimes = samples.map((m) => m.time).toList();
 
     // this will probably be slightly different than the requested sample window
-    var actualSampleWindow = samples.first.sampleTime - samples.last.sampleTime;
+    var actualSampleWindow = samples.last.time - samples.first.time;
 
     // get a list of equally spaced sample times between the start and end
     // of the sample window
-    var timestep = actualSampleWindow / samples.length;
+    // This might be a bad approach depending on the variance in the
+    // scale's reporting - investigate better solutions?
+    var timestep = actualSampleWindow / (samples.length - 1);
+
     var interpolatedSampleTimes =
-        List.generate(samples.length, (i) => i * timestep + samples.last.sampleTime);
+        List.generate(samples.length, (i) => i * timestep + samples.first.time);
+
+    log.info("hmmmm $actualSampleWindow $timestep $interpolatedSampleTimes $selectedSampleTimes");
 
     var interpolatedSampleWeights = interp(
         interpolatedSampleTimes, selectedSampleTimes, selectedSampleWeights);
 
     // These values for data smoothing, trend smoothing factors were found by
     // minimizing square error of forecast weights on real shot data
-    var smoothed = doubleExponentialSmoothing(interpolatedSampleWeights, 0.6, 0.5);
+    var smoothed =
+        doubleExponentialSmoothing(interpolatedSampleWeights, 0.6, 0.5);
 
     // double exponential forecast is given by adding b * m to the last smoothed
     // value, where "m" is a discrete number of time steps.
@@ -1204,13 +1210,22 @@ class EspressoMachineService extends ChangeNotifier {
     var fudgeFactor = b / b_2;
     fudgeFactor = fudgeFactor.isFinite ? fudgeFactor : 1;
 
+    var flow = gradient * fudgeFactor;
+
+    // The last weight sample probably occurred a little before "now"
+    // so the time would be a little too late without this adjustment
+    var timeOffset = interpolatedSampleTimes.last - sampleWindowEnd;
+
     log.info("weight samples $selectedSampleWeights");
     log.info("time samples $selectedSampleTimes");
     log.info("interpolated weight samples $interpolatedSampleWeights");
     log.info("interpolated time samples $interpolatedSampleTimes");
     log.info("exp smooth result $smoothed");
+    log.info("flow rate forecast $flow");
+    log.info("time offset $timeOffset");
 
-    return gradient * fudgeFactor;
+    var remainingWeight = targetWeight - samples.last.weight.weight;
+    return remainingWeight / flow + timeOffset;
   }
 
   void notify() {

--- a/lib/model/services/state/coffee_service.dart
+++ b/lib/model/services/state/coffee_service.dart
@@ -115,7 +115,7 @@ class CoffeeService extends ChangeNotifier {
       if (roasterBox.count() == 0) {
         log.info("No roasters available. Creating a default one.");
         var r = Roaster();
-        r.name = "Default Rouaster";
+        r.name = "Default Roaster";
         selectedRoasterId = roasterBox.put(r);
         settings.selectedRoaster = selectedRoasterId;
       }

--- a/lib/model/services/state/profile_service.dart
+++ b/lib/model/services/state/profile_service.dart
@@ -254,6 +254,7 @@ class ProfileService extends ChangeNotifier {
       file.deleteSync();
     }
     await file.create();
+
     var json = profile.toJson();
     log.info("Save json $json");
 
@@ -344,6 +345,7 @@ class ProfileService extends ChangeNotifier {
       buffer.writeln("{");
       buffer.writeln('"name": "${step.name}",');
       buffer.writeln('"temperature": "${step.temp}",');
+      buffer.writeln('"weight": "${step.maxWeight}",');
 
       var sensor = (step.flag & TMixTemp == TMixTemp) ? "water" : "coffee";
       buffer.writeln('"sensor": "$sensor",');
@@ -468,6 +470,7 @@ class ProfileService extends ChangeNotifier {
 
       frame.pump = dynamic2String(frameData["pump"]);
       frame.name = dynamic2String(frameData["name"]);
+      frame.maxWeight = dynamic2Double(frameData["weight"]);
 
       // flow control
       if (!frameData.containsKey("pump")) return false;

--- a/lib/model/services/state/settings_service.dart
+++ b/lib/model/services/state/settings_service.dart
@@ -222,7 +222,7 @@ class SettingsService extends ChangeNotifier {
       Settings.setValue<double>(SettingKeys.targetEspressoWeightTimeAdjust.name, value);
 
   double get stepLimitWeightTimeAdjust =>
-      Settings.getValue<double>(SettingKeys.stepLimitWeightTimeAdjust.name) ?? -0.5;
+      Settings.getValue<double>(SettingKeys.stepLimitWeightTimeAdjust.name) ?? 0.0;
   set stepLimitWeightTimeAdjust(value) =>
       Settings.setValue<double>(SettingKeys.stepLimitWeightTimeAdjust.name, value);
 

--- a/lib/model/services/state/settings_service.dart
+++ b/lib/model/services/state/settings_service.dart
@@ -222,7 +222,7 @@ class SettingsService extends ChangeNotifier {
       Settings.setValue<double>(SettingKeys.targetEspressoWeightTimeAdjust.name, value);
 
   double get stepLimitWeightTimeAdjust =>
-      Settings.getValue<double>(SettingKeys.stepLimitWeightTimeAdjust.name) ?? 0.5;
+      Settings.getValue<double>(SettingKeys.stepLimitWeightTimeAdjust.name) ?? -0.5;
   set stepLimitWeightTimeAdjust(value) =>
       Settings.setValue<double>(SettingKeys.stepLimitWeightTimeAdjust.name, value);
 

--- a/lib/model/services/state/settings_service.dart
+++ b/lib/model/services/state/settings_service.dart
@@ -50,6 +50,7 @@ enum SettingKeys {
   targetGroupTemp,
   targetEspressoWeight,
   targetEspressoWeightTimeAdjust,
+  stepLimitWeightTimeAdjust,
   targetWaterlevel,
   webServer,
   targetTempCorrection,
@@ -219,6 +220,11 @@ class SettingsService extends ChangeNotifier {
       Settings.getValue<double>(SettingKeys.targetEspressoWeightTimeAdjust.name) ?? 0.5;
   set targetEspressoWeightTimeAdjust(value) =>
       Settings.setValue<double>(SettingKeys.targetEspressoWeightTimeAdjust.name, value);
+
+  double get stepLimitWeightTimeAdjust =>
+      Settings.getValue<double>(SettingKeys.stepLimitWeightTimeAdjust.name) ?? 0.5;
+  set stepLimitWeightTimeAdjust(value) =>
+      Settings.setValue<double>(SettingKeys.stepLimitWeightTimeAdjust.name, value);
 
   double get targetFlushTime => Settings.getValue<double>(SettingKeys.targetFlushTime.name) ?? 3.0;
   set targetFlushTime(double value) => Settings.setValue<double>(SettingKeys.targetFlushTime.name, value);

--- a/lib/objectbox.g.dart
+++ b/lib/objectbox.g.dart
@@ -30,8 +30,16 @@ final _entities = <ModelEntity>[
       lastPropertyId: const IdUid(29, 7092783304172893944),
       flags: 0,
       properties: <ModelProperty>[
-        ModelProperty(id: const IdUid(1, 3409921168948181785), name: 'id', type: 6, flags: 1),
-        ModelProperty(id: const IdUid(2, 2023678536313964966), name: 'date', type: 10, flags: 0),
+        ModelProperty(
+            id: const IdUid(1, 3409921168948181785),
+            name: 'id',
+            type: 6,
+            flags: 1),
+        ModelProperty(
+            id: const IdUid(2, 2023678536313964966),
+            name: 'date',
+            type: 10,
+            flags: 0),
         ModelProperty(
             id: const IdUid(3, 8622027867479492178),
             name: 'coffeeId',
@@ -39,11 +47,31 @@ final _entities = <ModelEntity>[
             flags: 520,
             indexId: const IdUid(3, 6812967169057673456),
             relationTarget: 'Coffee'),
-        ModelProperty(id: const IdUid(4, 8755594923067759447), name: 'profileId', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(5, 5926041023112911997), name: 'pourTime', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(6, 3371539309151542209), name: 'pourWeight', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(7, 2364668778724218869), name: 'targetEspressoWeight', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(8, 3676925190157138581), name: 'targetTempCorrection', type: 8, flags: 0),
+        ModelProperty(
+            id: const IdUid(4, 8755594923067759447),
+            name: 'profileId',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(5, 5926041023112911997),
+            name: 'pourTime',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(6, 3371539309151542209),
+            name: 'pourWeight',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(7, 2364668778724218869),
+            name: 'targetEspressoWeight',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(8, 3676925190157138581),
+            name: 'targetTempCorrection',
+            type: 8,
+            flags: 0),
         ModelProperty(
             id: const IdUid(9, 111349150896732313),
             name: 'recipeId',
@@ -51,29 +79,107 @@ final _entities = <ModelEntity>[
             flags: 520,
             indexId: const IdUid(6, 446388852719725051),
             relationTarget: 'Recipe'),
-        ModelProperty(id: const IdUid(10, 7125372405899859202), name: 'doseWeight', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(11, 3218706867177652460), name: 'drinkWeight', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(12, 843222103065987409), name: 'grinderSettings', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(13, 3391691028545881063), name: 'description', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(14, 7115326853722345534), name: 'grinderName', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(15, 1080541265960096120), name: 'roastingDate', type: 10, flags: 0),
-        ModelProperty(id: const IdUid(17, 8073143111153977311), name: 'extractionYield', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(18, 6900766595761360168), name: 'enjoyment', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(19, 1657747884825847241), name: 'barrista', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(20, 1949502433090459020), name: 'drinker', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(21, 3188265368046958522), name: 'totalDissolvedSolids', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(22, 7608631056957421432), name: 'visualizerId', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(23, 2565185120432732135), name: 'estimatedWeightReachedTime', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(24, 7385542231737088542), name: 'estimatedWeight_m', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(25, 1614129143662966902), name: 'estimatedWeight_b', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(26, 3360550099619244198), name: 'estimatedWeight_tEnd', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(27, 7751808523866622917), name: 'estimatedWeight_tStart', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(28, 7560094062746893331), name: 'ratio1', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(29, 7092783304172893944), name: 'ratio2', type: 8, flags: 0)
+        ModelProperty(
+            id: const IdUid(10, 7125372405899859202),
+            name: 'doseWeight',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(11, 3218706867177652460),
+            name: 'drinkWeight',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(12, 843222103065987409),
+            name: 'grinderSettings',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(13, 3391691028545881063),
+            name: 'description',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(14, 7115326853722345534),
+            name: 'grinderName',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(15, 1080541265960096120),
+            name: 'roastingDate',
+            type: 10,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(17, 8073143111153977311),
+            name: 'extractionYield',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(18, 6900766595761360168),
+            name: 'enjoyment',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(19, 1657747884825847241),
+            name: 'barrista',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(20, 1949502433090459020),
+            name: 'drinker',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(21, 3188265368046958522),
+            name: 'totalDissolvedSolids',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(22, 7608631056957421432),
+            name: 'visualizerId',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(23, 2565185120432732135),
+            name: 'estimatedWeightReachedTime',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(24, 7385542231737088542),
+            name: 'estimatedWeight_m',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(25, 1614129143662966902),
+            name: 'estimatedWeight_b',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(26, 3360550099619244198),
+            name: 'estimatedWeight_tEnd',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(27, 7751808523866622917),
+            name: 'estimatedWeight_tStart',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(28, 7560094062746893331),
+            name: 'ratio1',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(29, 7092783304172893944),
+            name: 'ratio2',
+            type: 8,
+            flags: 0)
       ],
       relations: <ModelRelation>[
         ModelRelation(
-            id: const IdUid(1, 2516218059471133212), name: 'shotstates', targetId: const IdUid(7, 7915358336460233027))
+            id: const IdUid(1, 2516218059471133212),
+            name: 'shotstates',
+            targetId: const IdUid(7, 7915358336460233027))
       ],
       backlinks: <ModelBacklink>[]),
   ModelEntity(
@@ -82,8 +188,16 @@ final _entities = <ModelEntity>[
       lastPropertyId: const IdUid(22, 6473077172521626198),
       flags: 0,
       properties: <ModelProperty>[
-        ModelProperty(id: const IdUid(1, 5615950171516587099), name: 'id', type: 6, flags: 1),
-        ModelProperty(id: const IdUid(2, 8472885439572250925), name: 'name', type: 9, flags: 0),
+        ModelProperty(
+            id: const IdUid(1, 5615950171516587099),
+            name: 'id',
+            type: 6,
+            flags: 1),
+        ModelProperty(
+            id: const IdUid(2, 8472885439572250925),
+            name: 'name',
+            type: 9,
+            flags: 0),
         ModelProperty(
             id: const IdUid(3, 5110044840806149074),
             name: 'roasterId',
@@ -91,23 +205,91 @@ final _entities = <ModelEntity>[
             flags: 520,
             indexId: const IdUid(2, 3069173701919379915),
             relationTarget: 'Roaster'),
-        ModelProperty(id: const IdUid(4, 5457947097987531063), name: 'imageURL', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(5, 4303540774085095790), name: 'grinderSettings', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(6, 225021759355650432), name: 'acidRating', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(7, 6130861246586256372), name: 'intensityRating', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(8, 1334308936684528664), name: 'roastLevel', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(11, 5546651948055766963), name: 'description', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(12, 1497565644929136769), name: 'origin', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(13, 8572628874963105062), name: 'price', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(14, 7230184989598744286), name: 'type', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(15, 6441439649929911062), name: 'taste', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(16, 3584125557140279811), name: 'grinderDoseWeight', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(17, 3180181574963034735), name: 'roastDate', type: 10, flags: 0),
-        ModelProperty(id: const IdUid(18, 6938000416295761114), name: 'region', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(19, 9026359374085873224), name: 'farm', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(20, 5729031423788409720), name: 'cropyear', type: 10, flags: 0),
-        ModelProperty(id: const IdUid(21, 6055219836272863790), name: 'process', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(22, 6473077172521626198), name: 'elevation', type: 6, flags: 0)
+        ModelProperty(
+            id: const IdUid(4, 5457947097987531063),
+            name: 'imageURL',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(5, 4303540774085095790),
+            name: 'grinderSettings',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(6, 225021759355650432),
+            name: 'acidRating',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(7, 6130861246586256372),
+            name: 'intensityRating',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(8, 1334308936684528664),
+            name: 'roastLevel',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(11, 5546651948055766963),
+            name: 'description',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(12, 1497565644929136769),
+            name: 'origin',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(13, 8572628874963105062),
+            name: 'price',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(14, 7230184989598744286),
+            name: 'type',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(15, 6441439649929911062),
+            name: 'taste',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(16, 3584125557140279811),
+            name: 'grinderDoseWeight',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(17, 3180181574963034735),
+            name: 'roastDate',
+            type: 10,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(18, 6938000416295761114),
+            name: 'region',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(19, 9026359374085873224),
+            name: 'farm',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(20, 5729031423788409720),
+            name: 'cropyear',
+            type: 10,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(21, 6055219836272863790),
+            name: 'process',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(22, 6473077172521626198),
+            name: 'elevation',
+            type: 6,
+            flags: 0)
       ],
       relations: <ModelRelation>[],
       backlinks: <ModelBacklink>[]),
@@ -117,12 +299,36 @@ final _entities = <ModelEntity>[
       lastPropertyId: const IdUid(6, 970876983252056704),
       flags: 0,
       properties: <ModelProperty>[
-        ModelProperty(id: const IdUid(1, 5991058579053841031), name: 'id', type: 6, flags: 1),
-        ModelProperty(id: const IdUid(2, 2492045522554162963), name: 'name', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(3, 109766545405737050), name: 'imageURL', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(4, 9028335971533423619), name: 'description', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(5, 5316187485168323519), name: 'address', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(6, 970876983252056704), name: 'homepage', type: 9, flags: 0)
+        ModelProperty(
+            id: const IdUid(1, 5991058579053841031),
+            name: 'id',
+            type: 6,
+            flags: 1),
+        ModelProperty(
+            id: const IdUid(2, 2492045522554162963),
+            name: 'name',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(3, 109766545405737050),
+            name: 'imageURL',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(4, 9028335971533423619),
+            name: 'description',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(5, 5316187485168323519),
+            name: 'address',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(6, 970876983252056704),
+            name: 'homepage',
+            type: 9,
+            flags: 0)
       ],
       relations: <ModelRelation>[],
       backlinks: <ModelBacklink>[
@@ -134,23 +340,91 @@ final _entities = <ModelEntity>[
       lastPropertyId: const IdUid(17, 6151090906092388458),
       flags: 0,
       properties: <ModelProperty>[
-        ModelProperty(id: const IdUid(1, 5911801733392743346), name: 'id', type: 6, flags: 1),
-        ModelProperty(id: const IdUid(2, 873810899844548098), name: 'subState', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(3, 5430882212744780164), name: 'weight', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(4, 7057243266656013589), name: 'sampleTime', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(5, 7139045219632015353), name: 'sampleTimeCorrected', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(6, 8336035996648567372), name: 'pourTime', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(7, 3728387464400538728), name: 'groupPressure', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(8, 7163267269115276469), name: 'groupFlow', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(9, 3024067366106544243), name: 'mixTemp', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(10, 6481804704343187952), name: 'headTemp', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(11, 4452444150576753969), name: 'setMixTemp', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(12, 5828096454211460982), name: 'setHeadTemp', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(13, 6404583577823963796), name: 'setGroupPressure', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(14, 953787600600014188), name: 'setGroupFlow', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(15, 4614454596637650047), name: 'flowWeight', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(16, 8625810897882043509), name: 'frameNumber', type: 6, flags: 0),
-        ModelProperty(id: const IdUid(17, 6151090906092388458), name: 'steamTemp', type: 6, flags: 0)
+        ModelProperty(
+            id: const IdUid(1, 5911801733392743346),
+            name: 'id',
+            type: 6,
+            flags: 1),
+        ModelProperty(
+            id: const IdUid(2, 873810899844548098),
+            name: 'subState',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(3, 5430882212744780164),
+            name: 'weight',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(4, 7057243266656013589),
+            name: 'sampleTime',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(5, 7139045219632015353),
+            name: 'sampleTimeCorrected',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(6, 8336035996648567372),
+            name: 'pourTime',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(7, 3728387464400538728),
+            name: 'groupPressure',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(8, 7163267269115276469),
+            name: 'groupFlow',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(9, 3024067366106544243),
+            name: 'mixTemp',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(10, 6481804704343187952),
+            name: 'headTemp',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(11, 4452444150576753969),
+            name: 'setMixTemp',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(12, 5828096454211460982),
+            name: 'setHeadTemp',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(13, 6404583577823963796),
+            name: 'setGroupPressure',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(14, 953787600600014188),
+            name: 'setGroupFlow',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(15, 4614454596637650047),
+            name: 'flowWeight',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(16, 8625810897882043509),
+            name: 'frameNumber',
+            type: 6,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(17, 6151090906092388458),
+            name: 'steamTemp',
+            type: 6,
+            flags: 0)
       ],
       relations: <ModelRelation>[],
       backlinks: <ModelBacklink>[]),
@@ -160,7 +434,11 @@ final _entities = <ModelEntity>[
       lastPropertyId: const IdUid(2, 6993582572867488081),
       flags: 0,
       properties: <ModelProperty>[
-        ModelProperty(id: const IdUid(1, 9118758589013466597), name: 'id', type: 6, flags: 1),
+        ModelProperty(
+            id: const IdUid(1, 9118758589013466597),
+            name: 'id',
+            type: 6,
+            flags: 1),
         ModelProperty(
             id: const IdUid(2, 6993582572867488081),
             name: 'recipeId',
@@ -177,7 +455,11 @@ final _entities = <ModelEntity>[
       lastPropertyId: const IdUid(27, 5975506820285440095),
       flags: 0,
       properties: <ModelProperty>[
-        ModelProperty(id: const IdUid(1, 4913052187613295020), name: 'id', type: 6, flags: 1),
+        ModelProperty(
+            id: const IdUid(1, 4913052187613295020),
+            name: 'id',
+            type: 6,
+            flags: 1),
         ModelProperty(
             id: const IdUid(2, 7810214585185210043),
             name: 'coffeeId',
@@ -185,29 +467,121 @@ final _entities = <ModelEntity>[
             flags: 520,
             indexId: const IdUid(5, 7106111853969068341),
             relationTarget: 'Coffee'),
-        ModelProperty(id: const IdUid(3, 1845236010514477562), name: 'adjustedWeight', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(4, 8386295331633147748), name: 'adjustedPressure', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(5, 4533756232448450794), name: 'adjustedTemp', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(6, 3891072045656880456), name: 'name', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(7, 647131839827812853), name: 'profileId', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(8, 3008075691008235314), name: 'grinderDoseWeight', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(9, 3336924770577751042), name: 'grinderSettings', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(10, 3868213321838280891), name: 'isDeleted', type: 1, flags: 0),
-        ModelProperty(id: const IdUid(11, 4204171820753323126), name: 'isFavorite', type: 1, flags: 0),
-        ModelProperty(id: const IdUid(12, 3155549701286458303), name: 'ratio1', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(13, 1901110978839052278), name: 'ratio2', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(15, 7025254451475299925), name: 'weightWater', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(16, 15425906396748186), name: 'useWater', type: 1, flags: 0),
-        ModelProperty(id: const IdUid(17, 9055581799472750245), name: 'tempWater', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(18, 4711319393184164790), name: 'timeWater', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(19, 1770550326036569594), name: 'tempSteam', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(20, 6084341035853340078), name: 'flowSteam', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(21, 3919563489562326148), name: 'timeSteam', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(22, 2201822893454360106), name: 'weightMilk', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(23, 4030549021668168783), name: 'useSteam', type: 1, flags: 0),
-        ModelProperty(id: const IdUid(24, 5553698550197971705), name: 'description', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(25, 1050422726627456052), name: 'grinderModel', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(27, 5975506820285440095), name: 'disableStopOnWeight', type: 1, flags: 0)
+        ModelProperty(
+            id: const IdUid(3, 1845236010514477562),
+            name: 'adjustedWeight',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(4, 8386295331633147748),
+            name: 'adjustedPressure',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(5, 4533756232448450794),
+            name: 'adjustedTemp',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(6, 3891072045656880456),
+            name: 'name',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(7, 647131839827812853),
+            name: 'profileId',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(8, 3008075691008235314),
+            name: 'grinderDoseWeight',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(9, 3336924770577751042),
+            name: 'grinderSettings',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(10, 3868213321838280891),
+            name: 'isDeleted',
+            type: 1,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(11, 4204171820753323126),
+            name: 'isFavorite',
+            type: 1,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(12, 3155549701286458303),
+            name: 'ratio1',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(13, 1901110978839052278),
+            name: 'ratio2',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(15, 7025254451475299925),
+            name: 'weightWater',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(16, 15425906396748186),
+            name: 'useWater',
+            type: 1,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(17, 9055581799472750245),
+            name: 'tempWater',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(18, 4711319393184164790),
+            name: 'timeWater',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(19, 1770550326036569594),
+            name: 'tempSteam',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(20, 6084341035853340078),
+            name: 'flowSteam',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(21, 3919563489562326148),
+            name: 'timeSteam',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(22, 2201822893454360106),
+            name: 'weightMilk',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(23, 4030549021668168783),
+            name: 'useSteam',
+            type: 1,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(24, 5553698550197971705),
+            name: 'description',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(25, 1050422726627456052),
+            name: 'grinderModel',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(27, 5975506820285440095),
+            name: 'disableStopOnWeight',
+            type: 1,
+            flags: 0)
       ],
       relations: <ModelRelation>[],
       backlinks: <ModelBacklink>[]),
@@ -217,18 +591,42 @@ final _entities = <ModelEntity>[
       lastPropertyId: const IdUid(7, 649428367441394162),
       flags: 0,
       properties: <ModelProperty>[
-        ModelProperty(id: const IdUid(1, 5338240427175828934), name: 'id', type: 6, flags: 1),
-        ModelProperty(id: const IdUid(2, 8227203168176223394), name: 'doubleVal', type: 8, flags: 0),
-        ModelProperty(id: const IdUid(3, 4672631448573261939), name: 'intVal', type: 6, flags: 0),
-        ModelProperty(id: const IdUid(4, 6775070129254440298), name: 'stringVal', type: 9, flags: 0),
-        ModelProperty(id: const IdUid(5, 6064803487869840239), name: 'boolVal', type: 1, flags: 0),
+        ModelProperty(
+            id: const IdUid(1, 5338240427175828934),
+            name: 'id',
+            type: 6,
+            flags: 1),
+        ModelProperty(
+            id: const IdUid(2, 8227203168176223394),
+            name: 'doubleVal',
+            type: 8,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(3, 4672631448573261939),
+            name: 'intVal',
+            type: 6,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(4, 6775070129254440298),
+            name: 'stringVal',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(5, 6064803487869840239),
+            name: 'boolVal',
+            type: 1,
+            flags: 0),
         ModelProperty(
             id: const IdUid(6, 7666011173201483948),
             name: 'key',
             type: 9,
             flags: 2048,
             indexId: const IdUid(8, 899743464370898125)),
-        ModelProperty(id: const IdUid(7, 649428367441394162), name: 'type', type: 9, flags: 0)
+        ModelProperty(
+            id: const IdUid(7, 649428367441394162),
+            name: 'type',
+            type: 9,
+            flags: 0)
       ],
       relations: <ModelRelation>[],
       backlinks: <ModelBacklink>[])
@@ -258,7 +656,12 @@ ModelDefinition getObjectBoxModel() {
       lastIndexId: const IdUid(8, 899743464370898125),
       lastRelationId: const IdUid(1, 2516218059471133212),
       lastSequenceId: const IdUid(0, 0),
-      retiredEntityUids: const [2372411160892302204, 5004946134676291479, 6316057013526616538, 4429298076511472570],
+      retiredEntityUids: const [
+        2372411160892302204,
+        5004946134676291479,
+        6316057013526616538,
+        4429298076511472570
+      ],
       retiredIndexUids: const [],
       retiredPropertyUids: const [
         5255554628564942194,
@@ -305,7 +708,8 @@ ModelDefinition getObjectBoxModel() {
     Shot: EntityDefinition<Shot>(
         model: _entities[0],
         toOneRelations: (Shot object) => [object.coffee, object.recipe],
-        toManyRelations: (Shot object) => {RelInfo<Shot>.toMany(1, object.id): object.shotstates},
+        toManyRelations: (Shot object) =>
+            {RelInfo<Shot>.toMany(1, object.id): object.shotstates},
         getId: (Shot object) => object.id,
         setId: (Shot object, int id) {
           object.id = id;
@@ -355,37 +759,64 @@ ModelDefinition getObjectBoxModel() {
 
           final object = Shot()
             ..id = const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0)
-            ..date = DateTime.fromMillisecondsSinceEpoch(const fb.Int64Reader().vTableGet(buffer, rootOffset, 6, 0))
-            ..profileId = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 10, '')
-            ..pourTime = const fb.Float64Reader().vTableGet(buffer, rootOffset, 12, 0)
-            ..pourWeight = const fb.Float64Reader().vTableGet(buffer, rootOffset, 14, 0)
-            ..targetEspressoWeight = const fb.Float64Reader().vTableGet(buffer, rootOffset, 16, 0)
-            ..targetTempCorrection = const fb.Float64Reader().vTableGet(buffer, rootOffset, 18, 0)
-            ..doseWeight = const fb.Float64Reader().vTableGet(buffer, rootOffset, 22, 0)
-            ..drinkWeight = const fb.Float64Reader().vTableGet(buffer, rootOffset, 24, 0)
-            ..grinderSettings = const fb.Float64Reader().vTableGet(buffer, rootOffset, 26, 0)
-            ..description = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 28, '')
-            ..grinderName = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 30, '')
-            ..roastingDate =
-                DateTime.fromMillisecondsSinceEpoch(const fb.Int64Reader().vTableGet(buffer, rootOffset, 32, 0))
-            ..extractionYield = const fb.Float64Reader().vTableGet(buffer, rootOffset, 36, 0)
-            ..enjoyment = const fb.Float64Reader().vTableGet(buffer, rootOffset, 38, 0)
-            ..barrista = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 40, '')
-            ..drinker = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 42, '')
-            ..totalDissolvedSolids = const fb.Float64Reader().vTableGet(buffer, rootOffset, 44, 0)
-            ..visualizerId = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 46, '')
-            ..estimatedWeightReachedTime = const fb.Float64Reader().vTableGet(buffer, rootOffset, 48, 0)
-            ..estimatedWeight_m = const fb.Float64Reader().vTableGet(buffer, rootOffset, 50, 0)
-            ..estimatedWeight_b = const fb.Float64Reader().vTableGet(buffer, rootOffset, 52, 0)
-            ..estimatedWeight_tEnd = const fb.Float64Reader().vTableGet(buffer, rootOffset, 54, 0)
-            ..estimatedWeight_tStart = const fb.Float64Reader().vTableGet(buffer, rootOffset, 56, 0)
-            ..ratio1 = const fb.Float64Reader().vTableGet(buffer, rootOffset, 58, 0)
-            ..ratio2 = const fb.Float64Reader().vTableGet(buffer, rootOffset, 60, 0);
-          object.coffee.targetId = const fb.Int64Reader().vTableGet(buffer, rootOffset, 8, 0);
+            ..date = DateTime.fromMillisecondsSinceEpoch(
+                const fb.Int64Reader().vTableGet(buffer, rootOffset, 6, 0))
+            ..profileId = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 10, '')
+            ..pourTime =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 12, 0)
+            ..pourWeight =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 14, 0)
+            ..targetEspressoWeight =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 16, 0)
+            ..targetTempCorrection =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 18, 0)
+            ..doseWeight =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 22, 0)
+            ..drinkWeight =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 24, 0)
+            ..grinderSettings =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 26, 0)
+            ..description = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 28, '')
+            ..grinderName = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 30, '')
+            ..roastingDate = DateTime.fromMillisecondsSinceEpoch(
+                const fb.Int64Reader().vTableGet(buffer, rootOffset, 32, 0))
+            ..extractionYield =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 36, 0)
+            ..enjoyment =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 38, 0)
+            ..barrista = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 40, '')
+            ..drinker = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 42, '')
+            ..totalDissolvedSolids =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 44, 0)
+            ..visualizerId = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 46, '')
+            ..estimatedWeightReachedTime =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 48, 0)
+            ..estimatedWeight_m =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 50, 0)
+            ..estimatedWeight_b =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 52, 0)
+            ..estimatedWeight_tEnd =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 54, 0)
+            ..estimatedWeight_tStart =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 56, 0)
+            ..ratio1 =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 58, 0)
+            ..ratio2 =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 60, 0);
+          object.coffee.targetId =
+              const fb.Int64Reader().vTableGet(buffer, rootOffset, 8, 0);
           object.coffee.attach(store);
-          object.recipe.targetId = const fb.Int64Reader().vTableGet(buffer, rootOffset, 20, 0);
+          object.recipe.targetId =
+              const fb.Int64Reader().vTableGet(buffer, rootOffset, 20, 0);
           object.recipe.attach(store);
-          InternalToManyAccess.setRelInfo<Shot>(object.shotstates, store, RelInfo<Shot>.toMany(1, object.id));
+          InternalToManyAccess.setRelInfo<Shot>(
+              object.shotstates, store, RelInfo<Shot>.toMany(1, object.id));
           return object;
         }),
     Coffee: EntityDefinition<Coffee>(
@@ -437,35 +868,55 @@ ModelDefinition getObjectBoxModel() {
 
           final object = Coffee()
             ..id = const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0)
-            ..name = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 6, '')
-            ..imageURL = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 10, '')
-            ..grinderSettings = const fb.Float64Reader().vTableGet(buffer, rootOffset, 12, 0)
-            ..acidRating = const fb.Float64Reader().vTableGet(buffer, rootOffset, 14, 0)
-            ..intensityRating = const fb.Float64Reader().vTableGet(buffer, rootOffset, 16, 0)
-            ..roastLevel = const fb.Float64Reader().vTableGet(buffer, rootOffset, 18, 0)
-            ..description = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 24, '')
-            ..origin = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 26, '')
-            ..price = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 28, '')
-            ..type = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 30, '')
-            ..taste = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 32, '')
-            ..grinderDoseWeight = const fb.Float64Reader().vTableGet(buffer, rootOffset, 34, 0)
-            ..roastDate =
-                DateTime.fromMillisecondsSinceEpoch(const fb.Int64Reader().vTableGet(buffer, rootOffset, 36, 0))
-            ..region = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 38, '')
-            ..farm = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 40, '')
-            ..cropyear =
-                DateTime.fromMillisecondsSinceEpoch(const fb.Int64Reader().vTableGet(buffer, rootOffset, 42, 0))
-            ..process = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 44, '')
-            ..elevation = const fb.Int64Reader().vTableGet(buffer, rootOffset, 46, 0);
-          object.roaster.targetId = const fb.Int64Reader().vTableGet(buffer, rootOffset, 8, 0);
+            ..name = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 6, '')
+            ..imageURL = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 10, '')
+            ..grinderSettings =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 12, 0)
+            ..acidRating =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 14, 0)
+            ..intensityRating =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 16, 0)
+            ..roastLevel =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 18, 0)
+            ..description = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 24, '')
+            ..origin = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 26, '')
+            ..price = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 28, '')
+            ..type = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 30, '')
+            ..taste = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 32, '')
+            ..grinderDoseWeight =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 34, 0)
+            ..roastDate = DateTime.fromMillisecondsSinceEpoch(
+                const fb.Int64Reader().vTableGet(buffer, rootOffset, 36, 0))
+            ..region = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 38, '')
+            ..farm = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 40, '')
+            ..cropyear = DateTime.fromMillisecondsSinceEpoch(
+                const fb.Int64Reader().vTableGet(buffer, rootOffset, 42, 0))
+            ..process = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 44, '')
+            ..elevation =
+                const fb.Int64Reader().vTableGet(buffer, rootOffset, 46, 0);
+          object.roaster.targetId =
+              const fb.Int64Reader().vTableGet(buffer, rootOffset, 8, 0);
           object.roaster.attach(store);
           return object;
         }),
     Roaster: EntityDefinition<Roaster>(
         model: _entities[2],
         toOneRelations: (Roaster object) => [],
-        toManyRelations: (Roaster object) =>
-            {RelInfo<Coffee>.toOneBacklink(3, object.id, (Coffee srcObject) => srcObject.roaster): object.coffees},
+        toManyRelations: (Roaster object) => {
+              RelInfo<Coffee>.toOneBacklink(
+                      3, object.id, (Coffee srcObject) => srcObject.roaster):
+                  object.coffees
+            },
         getId: (Roaster object) => object.id,
         setId: (Roaster object, int id) {
           object.id = id;
@@ -492,13 +943,21 @@ ModelDefinition getObjectBoxModel() {
 
           final object = Roaster()
             ..id = const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0)
-            ..name = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 6, '')
-            ..imageURL = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 8, '')
-            ..description = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 10, '')
-            ..address = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 12, '')
-            ..homepage = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 14, '');
-          InternalToManyAccess.setRelInfo<Roaster>(object.coffees, store,
-              RelInfo<Coffee>.toOneBacklink(3, object.id, (Coffee srcObject) => srcObject.roaster));
+            ..name = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 6, '')
+            ..imageURL = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 8, '')
+            ..description = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 10, '')
+            ..address = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 12, '')
+            ..homepage = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 14, '');
+          InternalToManyAccess.setRelInfo<Roaster>(
+              object.coffees,
+              store,
+              RelInfo<Coffee>.toOneBacklink(
+                  3, object.id, (Coffee srcObject) => srcObject.roaster));
           return object;
         }),
     ShotState: EntityDefinition<ShotState>(
@@ -550,10 +1009,13 @@ ModelDefinition getObjectBoxModel() {
               const fb.Int64Reader().vTableGet(buffer, rootOffset, 34, 0),
               const fb.Int64Reader().vTableGet(buffer, rootOffset, 36, 0),
               const fb.Float64Reader().vTableGet(buffer, rootOffset, 8, 0),
-              const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 6, ''))
+              const fb.StringReader(asciiOptimization: true)
+                  .vTableGet(buffer, rootOffset, 6, ''))
             ..id = const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0)
-            ..pourTime = const fb.Float64Reader().vTableGet(buffer, rootOffset, 14, 0)
-            ..flowWeight = const fb.Float64Reader().vTableGet(buffer, rootOffset, 32, 0);
+            ..pourTime =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 14, 0)
+            ..flowWeight =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 32, 0);
 
           return object;
         }),
@@ -576,8 +1038,10 @@ ModelDefinition getObjectBoxModel() {
           final buffer = fb.BufferContext(fbData);
           final rootOffset = buffer.derefObject(0);
 
-          final object = Favorite()..id = const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
-          object.recipe.targetId = const fb.Int64Reader().vTableGet(buffer, rootOffset, 6, 0);
+          final object = Favorite()
+            ..id = const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
+          object.recipe.targetId =
+              const fb.Int64Reader().vTableGet(buffer, rootOffset, 6, 0);
           object.recipe.attach(store);
           return object;
         }),
@@ -629,30 +1093,54 @@ ModelDefinition getObjectBoxModel() {
 
           final object = Recipe()
             ..id = const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0)
-            ..adjustedWeight = const fb.Float64Reader().vTableGet(buffer, rootOffset, 8, 0)
-            ..adjustedPressure = const fb.Float64Reader().vTableGet(buffer, rootOffset, 10, 0)
-            ..adjustedTemp = const fb.Float64Reader().vTableGet(buffer, rootOffset, 12, 0)
-            ..name = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 14, '')
-            ..profileId = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 16, '')
-            ..grinderDoseWeight = const fb.Float64Reader().vTableGet(buffer, rootOffset, 18, 0)
-            ..grinderSettings = const fb.Float64Reader().vTableGet(buffer, rootOffset, 20, 0)
-            ..isDeleted = const fb.BoolReader().vTableGet(buffer, rootOffset, 22, false)
-            ..isFavorite = const fb.BoolReader().vTableGet(buffer, rootOffset, 24, false)
-            ..ratio1 = const fb.Float64Reader().vTableGet(buffer, rootOffset, 26, 0)
-            ..ratio2 = const fb.Float64Reader().vTableGet(buffer, rootOffset, 28, 0)
-            ..weightWater = const fb.Float64Reader().vTableGet(buffer, rootOffset, 32, 0)
-            ..useWater = const fb.BoolReader().vTableGet(buffer, rootOffset, 34, false)
-            ..tempWater = const fb.Float64Reader().vTableGet(buffer, rootOffset, 36, 0)
-            ..timeWater = const fb.Float64Reader().vTableGet(buffer, rootOffset, 38, 0)
-            ..tempSteam = const fb.Float64Reader().vTableGet(buffer, rootOffset, 40, 0)
-            ..flowSteam = const fb.Float64Reader().vTableGet(buffer, rootOffset, 42, 0)
-            ..timeSteam = const fb.Float64Reader().vTableGet(buffer, rootOffset, 44, 0)
-            ..weightMilk = const fb.Float64Reader().vTableGet(buffer, rootOffset, 46, 0)
-            ..useSteam = const fb.BoolReader().vTableGet(buffer, rootOffset, 48, false)
-            ..description = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 50, '')
-            ..grinderModel = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 52, '')
-            ..disableStopOnWeight = const fb.BoolReader().vTableGet(buffer, rootOffset, 56, false);
-          object.coffee.targetId = const fb.Int64Reader().vTableGet(buffer, rootOffset, 6, 0);
+            ..adjustedWeight =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 8, 0)
+            ..adjustedPressure =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 10, 0)
+            ..adjustedTemp =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 12, 0)
+            ..name = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 14, '')
+            ..profileId = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 16, '')
+            ..grinderDoseWeight =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 18, 0)
+            ..grinderSettings =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 20, 0)
+            ..isDeleted =
+                const fb.BoolReader().vTableGet(buffer, rootOffset, 22, false)
+            ..isFavorite =
+                const fb.BoolReader().vTableGet(buffer, rootOffset, 24, false)
+            ..ratio1 =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 26, 0)
+            ..ratio2 =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 28, 0)
+            ..weightWater =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 32, 0)
+            ..useWater =
+                const fb.BoolReader().vTableGet(buffer, rootOffset, 34, false)
+            ..tempWater =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 36, 0)
+            ..timeWater =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 38, 0)
+            ..tempSteam =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 40, 0)
+            ..flowSteam =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 42, 0)
+            ..timeSteam =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 44, 0)
+            ..weightMilk =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 46, 0)
+            ..useSteam =
+                const fb.BoolReader().vTableGet(buffer, rootOffset, 48, false)
+            ..description = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 50, '')
+            ..grinderModel = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 52, '')
+            ..disableStopOnWeight =
+                const fb.BoolReader().vTableGet(buffer, rootOffset, 56, false);
+          object.coffee.targetId =
+              const fb.Int64Reader().vTableGet(buffer, rootOffset, 6, 0);
           object.coffee.attach(store);
           return object;
         }),
@@ -685,12 +1173,18 @@ ModelDefinition getObjectBoxModel() {
 
           final object = SettingsEntry()
             ..id = const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0)
-            ..doubleVal = const fb.Float64Reader().vTableGet(buffer, rootOffset, 6, 0)
-            ..intVal = const fb.Int64Reader().vTableGet(buffer, rootOffset, 8, 0)
-            ..stringVal = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 10, '')
-            ..boolVal = const fb.BoolReader().vTableGet(buffer, rootOffset, 12, false)
-            ..key = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 14, '')
-            ..type = const fb.StringReader(asciiOptimization: true).vTableGet(buffer, rootOffset, 16, '');
+            ..doubleVal =
+                const fb.Float64Reader().vTableGet(buffer, rootOffset, 6, 0)
+            ..intVal =
+                const fb.Int64Reader().vTableGet(buffer, rootOffset, 8, 0)
+            ..stringVal = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 10, '')
+            ..boolVal =
+                const fb.BoolReader().vTableGet(buffer, rootOffset, 12, false)
+            ..key = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 14, '')
+            ..type = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 16, '');
 
           return object;
         })
@@ -708,76 +1202,98 @@ class Shot_ {
   static final date = QueryIntegerProperty<Shot>(_entities[0].properties[1]);
 
   /// see [Shot.coffee]
-  static final coffee = QueryRelationToOne<Shot, Coffee>(_entities[0].properties[2]);
+  static final coffee =
+      QueryRelationToOne<Shot, Coffee>(_entities[0].properties[2]);
 
   /// see [Shot.profileId]
-  static final profileId = QueryStringProperty<Shot>(_entities[0].properties[3]);
+  static final profileId =
+      QueryStringProperty<Shot>(_entities[0].properties[3]);
 
   /// see [Shot.pourTime]
   static final pourTime = QueryDoubleProperty<Shot>(_entities[0].properties[4]);
 
   /// see [Shot.pourWeight]
-  static final pourWeight = QueryDoubleProperty<Shot>(_entities[0].properties[5]);
+  static final pourWeight =
+      QueryDoubleProperty<Shot>(_entities[0].properties[5]);
 
   /// see [Shot.targetEspressoWeight]
-  static final targetEspressoWeight = QueryDoubleProperty<Shot>(_entities[0].properties[6]);
+  static final targetEspressoWeight =
+      QueryDoubleProperty<Shot>(_entities[0].properties[6]);
 
   /// see [Shot.targetTempCorrection]
-  static final targetTempCorrection = QueryDoubleProperty<Shot>(_entities[0].properties[7]);
+  static final targetTempCorrection =
+      QueryDoubleProperty<Shot>(_entities[0].properties[7]);
 
   /// see [Shot.recipe]
-  static final recipe = QueryRelationToOne<Shot, Recipe>(_entities[0].properties[8]);
+  static final recipe =
+      QueryRelationToOne<Shot, Recipe>(_entities[0].properties[8]);
 
   /// see [Shot.doseWeight]
-  static final doseWeight = QueryDoubleProperty<Shot>(_entities[0].properties[9]);
+  static final doseWeight =
+      QueryDoubleProperty<Shot>(_entities[0].properties[9]);
 
   /// see [Shot.drinkWeight]
-  static final drinkWeight = QueryDoubleProperty<Shot>(_entities[0].properties[10]);
+  static final drinkWeight =
+      QueryDoubleProperty<Shot>(_entities[0].properties[10]);
 
   /// see [Shot.grinderSettings]
-  static final grinderSettings = QueryDoubleProperty<Shot>(_entities[0].properties[11]);
+  static final grinderSettings =
+      QueryDoubleProperty<Shot>(_entities[0].properties[11]);
 
   /// see [Shot.description]
-  static final description = QueryStringProperty<Shot>(_entities[0].properties[12]);
+  static final description =
+      QueryStringProperty<Shot>(_entities[0].properties[12]);
 
   /// see [Shot.grinderName]
-  static final grinderName = QueryStringProperty<Shot>(_entities[0].properties[13]);
+  static final grinderName =
+      QueryStringProperty<Shot>(_entities[0].properties[13]);
 
   /// see [Shot.roastingDate]
-  static final roastingDate = QueryIntegerProperty<Shot>(_entities[0].properties[14]);
+  static final roastingDate =
+      QueryIntegerProperty<Shot>(_entities[0].properties[14]);
 
   /// see [Shot.extractionYield]
-  static final extractionYield = QueryDoubleProperty<Shot>(_entities[0].properties[15]);
+  static final extractionYield =
+      QueryDoubleProperty<Shot>(_entities[0].properties[15]);
 
   /// see [Shot.enjoyment]
-  static final enjoyment = QueryDoubleProperty<Shot>(_entities[0].properties[16]);
+  static final enjoyment =
+      QueryDoubleProperty<Shot>(_entities[0].properties[16]);
 
   /// see [Shot.barrista]
-  static final barrista = QueryStringProperty<Shot>(_entities[0].properties[17]);
+  static final barrista =
+      QueryStringProperty<Shot>(_entities[0].properties[17]);
 
   /// see [Shot.drinker]
   static final drinker = QueryStringProperty<Shot>(_entities[0].properties[18]);
 
   /// see [Shot.totalDissolvedSolids]
-  static final totalDissolvedSolids = QueryDoubleProperty<Shot>(_entities[0].properties[19]);
+  static final totalDissolvedSolids =
+      QueryDoubleProperty<Shot>(_entities[0].properties[19]);
 
   /// see [Shot.visualizerId]
-  static final visualizerId = QueryStringProperty<Shot>(_entities[0].properties[20]);
+  static final visualizerId =
+      QueryStringProperty<Shot>(_entities[0].properties[20]);
 
   /// see [Shot.estimatedWeightReachedTime]
-  static final estimatedWeightReachedTime = QueryDoubleProperty<Shot>(_entities[0].properties[21]);
+  static final estimatedWeightReachedTime =
+      QueryDoubleProperty<Shot>(_entities[0].properties[21]);
 
   /// see [Shot.estimatedWeight_m]
-  static final estimatedWeight_m = QueryDoubleProperty<Shot>(_entities[0].properties[22]);
+  static final estimatedWeight_m =
+      QueryDoubleProperty<Shot>(_entities[0].properties[22]);
 
   /// see [Shot.estimatedWeight_b]
-  static final estimatedWeight_b = QueryDoubleProperty<Shot>(_entities[0].properties[23]);
+  static final estimatedWeight_b =
+      QueryDoubleProperty<Shot>(_entities[0].properties[23]);
 
   /// see [Shot.estimatedWeight_tEnd]
-  static final estimatedWeight_tEnd = QueryDoubleProperty<Shot>(_entities[0].properties[24]);
+  static final estimatedWeight_tEnd =
+      QueryDoubleProperty<Shot>(_entities[0].properties[24]);
 
   /// see [Shot.estimatedWeight_tStart]
-  static final estimatedWeight_tStart = QueryDoubleProperty<Shot>(_entities[0].properties[25]);
+  static final estimatedWeight_tStart =
+      QueryDoubleProperty<Shot>(_entities[0].properties[25]);
 
   /// see [Shot.ratio1]
   static final ratio1 = QueryDoubleProperty<Shot>(_entities[0].properties[26]);
@@ -786,7 +1302,8 @@ class Shot_ {
   static final ratio2 = QueryDoubleProperty<Shot>(_entities[0].properties[27]);
 
   /// see [Shot.shotstates]
-  static final shotstates = QueryRelationToMany<Shot, ShotState>(_entities[0].relations[0]);
+  static final shotstates =
+      QueryRelationToMany<Shot, ShotState>(_entities[0].relations[0]);
 }
 
 /// [Coffee] entity fields to define ObjectBox queries.
@@ -798,25 +1315,32 @@ class Coffee_ {
   static final name = QueryStringProperty<Coffee>(_entities[1].properties[1]);
 
   /// see [Coffee.roaster]
-  static final roaster = QueryRelationToOne<Coffee, Roaster>(_entities[1].properties[2]);
+  static final roaster =
+      QueryRelationToOne<Coffee, Roaster>(_entities[1].properties[2]);
 
   /// see [Coffee.imageURL]
-  static final imageURL = QueryStringProperty<Coffee>(_entities[1].properties[3]);
+  static final imageURL =
+      QueryStringProperty<Coffee>(_entities[1].properties[3]);
 
   /// see [Coffee.grinderSettings]
-  static final grinderSettings = QueryDoubleProperty<Coffee>(_entities[1].properties[4]);
+  static final grinderSettings =
+      QueryDoubleProperty<Coffee>(_entities[1].properties[4]);
 
   /// see [Coffee.acidRating]
-  static final acidRating = QueryDoubleProperty<Coffee>(_entities[1].properties[5]);
+  static final acidRating =
+      QueryDoubleProperty<Coffee>(_entities[1].properties[5]);
 
   /// see [Coffee.intensityRating]
-  static final intensityRating = QueryDoubleProperty<Coffee>(_entities[1].properties[6]);
+  static final intensityRating =
+      QueryDoubleProperty<Coffee>(_entities[1].properties[6]);
 
   /// see [Coffee.roastLevel]
-  static final roastLevel = QueryDoubleProperty<Coffee>(_entities[1].properties[7]);
+  static final roastLevel =
+      QueryDoubleProperty<Coffee>(_entities[1].properties[7]);
 
   /// see [Coffee.description]
-  static final description = QueryStringProperty<Coffee>(_entities[1].properties[8]);
+  static final description =
+      QueryStringProperty<Coffee>(_entities[1].properties[8]);
 
   /// see [Coffee.origin]
   static final origin = QueryStringProperty<Coffee>(_entities[1].properties[9]);
@@ -831,25 +1355,31 @@ class Coffee_ {
   static final taste = QueryStringProperty<Coffee>(_entities[1].properties[12]);
 
   /// see [Coffee.grinderDoseWeight]
-  static final grinderDoseWeight = QueryDoubleProperty<Coffee>(_entities[1].properties[13]);
+  static final grinderDoseWeight =
+      QueryDoubleProperty<Coffee>(_entities[1].properties[13]);
 
   /// see [Coffee.roastDate]
-  static final roastDate = QueryIntegerProperty<Coffee>(_entities[1].properties[14]);
+  static final roastDate =
+      QueryIntegerProperty<Coffee>(_entities[1].properties[14]);
 
   /// see [Coffee.region]
-  static final region = QueryStringProperty<Coffee>(_entities[1].properties[15]);
+  static final region =
+      QueryStringProperty<Coffee>(_entities[1].properties[15]);
 
   /// see [Coffee.farm]
   static final farm = QueryStringProperty<Coffee>(_entities[1].properties[16]);
 
   /// see [Coffee.cropyear]
-  static final cropyear = QueryIntegerProperty<Coffee>(_entities[1].properties[17]);
+  static final cropyear =
+      QueryIntegerProperty<Coffee>(_entities[1].properties[17]);
 
   /// see [Coffee.process]
-  static final process = QueryStringProperty<Coffee>(_entities[1].properties[18]);
+  static final process =
+      QueryStringProperty<Coffee>(_entities[1].properties[18]);
 
   /// see [Coffee.elevation]
-  static final elevation = QueryIntegerProperty<Coffee>(_entities[1].properties[19]);
+  static final elevation =
+      QueryIntegerProperty<Coffee>(_entities[1].properties[19]);
 }
 
 /// [Roaster] entity fields to define ObjectBox queries.
@@ -861,16 +1391,20 @@ class Roaster_ {
   static final name = QueryStringProperty<Roaster>(_entities[2].properties[1]);
 
   /// see [Roaster.imageURL]
-  static final imageURL = QueryStringProperty<Roaster>(_entities[2].properties[2]);
+  static final imageURL =
+      QueryStringProperty<Roaster>(_entities[2].properties[2]);
 
   /// see [Roaster.description]
-  static final description = QueryStringProperty<Roaster>(_entities[2].properties[3]);
+  static final description =
+      QueryStringProperty<Roaster>(_entities[2].properties[3]);
 
   /// see [Roaster.address]
-  static final address = QueryStringProperty<Roaster>(_entities[2].properties[4]);
+  static final address =
+      QueryStringProperty<Roaster>(_entities[2].properties[4]);
 
   /// see [Roaster.homepage]
-  static final homepage = QueryStringProperty<Roaster>(_entities[2].properties[5]);
+  static final homepage =
+      QueryStringProperty<Roaster>(_entities[2].properties[5]);
 }
 
 /// [ShotState] entity fields to define ObjectBox queries.
@@ -879,52 +1413,68 @@ class ShotState_ {
   static final id = QueryIntegerProperty<ShotState>(_entities[3].properties[0]);
 
   /// see [ShotState.subState]
-  static final subState = QueryStringProperty<ShotState>(_entities[3].properties[1]);
+  static final subState =
+      QueryStringProperty<ShotState>(_entities[3].properties[1]);
 
   /// see [ShotState.weight]
-  static final weight = QueryDoubleProperty<ShotState>(_entities[3].properties[2]);
+  static final weight =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[2]);
 
   /// see [ShotState.sampleTime]
-  static final sampleTime = QueryDoubleProperty<ShotState>(_entities[3].properties[3]);
+  static final sampleTime =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[3]);
 
   /// see [ShotState.sampleTimeCorrected]
-  static final sampleTimeCorrected = QueryDoubleProperty<ShotState>(_entities[3].properties[4]);
+  static final sampleTimeCorrected =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[4]);
 
   /// see [ShotState.pourTime]
-  static final pourTime = QueryDoubleProperty<ShotState>(_entities[3].properties[5]);
+  static final pourTime =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[5]);
 
   /// see [ShotState.groupPressure]
-  static final groupPressure = QueryDoubleProperty<ShotState>(_entities[3].properties[6]);
+  static final groupPressure =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[6]);
 
   /// see [ShotState.groupFlow]
-  static final groupFlow = QueryDoubleProperty<ShotState>(_entities[3].properties[7]);
+  static final groupFlow =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[7]);
 
   /// see [ShotState.mixTemp]
-  static final mixTemp = QueryDoubleProperty<ShotState>(_entities[3].properties[8]);
+  static final mixTemp =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[8]);
 
   /// see [ShotState.headTemp]
-  static final headTemp = QueryDoubleProperty<ShotState>(_entities[3].properties[9]);
+  static final headTemp =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[9]);
 
   /// see [ShotState.setMixTemp]
-  static final setMixTemp = QueryDoubleProperty<ShotState>(_entities[3].properties[10]);
+  static final setMixTemp =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[10]);
 
   /// see [ShotState.setHeadTemp]
-  static final setHeadTemp = QueryDoubleProperty<ShotState>(_entities[3].properties[11]);
+  static final setHeadTemp =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[11]);
 
   /// see [ShotState.setGroupPressure]
-  static final setGroupPressure = QueryDoubleProperty<ShotState>(_entities[3].properties[12]);
+  static final setGroupPressure =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[12]);
 
   /// see [ShotState.setGroupFlow]
-  static final setGroupFlow = QueryDoubleProperty<ShotState>(_entities[3].properties[13]);
+  static final setGroupFlow =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[13]);
 
   /// see [ShotState.flowWeight]
-  static final flowWeight = QueryDoubleProperty<ShotState>(_entities[3].properties[14]);
+  static final flowWeight =
+      QueryDoubleProperty<ShotState>(_entities[3].properties[14]);
 
   /// see [ShotState.frameNumber]
-  static final frameNumber = QueryIntegerProperty<ShotState>(_entities[3].properties[15]);
+  static final frameNumber =
+      QueryIntegerProperty<ShotState>(_entities[3].properties[15]);
 
   /// see [ShotState.steamTemp]
-  static final steamTemp = QueryIntegerProperty<ShotState>(_entities[3].properties[16]);
+  static final steamTemp =
+      QueryIntegerProperty<ShotState>(_entities[3].properties[16]);
 }
 
 /// [Favorite] entity fields to define ObjectBox queries.
@@ -933,7 +1483,8 @@ class Favorite_ {
   static final id = QueryIntegerProperty<Favorite>(_entities[4].properties[0]);
 
   /// see [Favorite.recipe]
-  static final recipe = QueryRelationToOne<Favorite, Recipe>(_entities[4].properties[1]);
+  static final recipe =
+      QueryRelationToOne<Favorite, Recipe>(_entities[4].properties[1]);
 }
 
 /// [Recipe] entity fields to define ObjectBox queries.
@@ -942,98 +1493,128 @@ class Recipe_ {
   static final id = QueryIntegerProperty<Recipe>(_entities[5].properties[0]);
 
   /// see [Recipe.coffee]
-  static final coffee = QueryRelationToOne<Recipe, Coffee>(_entities[5].properties[1]);
+  static final coffee =
+      QueryRelationToOne<Recipe, Coffee>(_entities[5].properties[1]);
 
   /// see [Recipe.adjustedWeight]
-  static final adjustedWeight = QueryDoubleProperty<Recipe>(_entities[5].properties[2]);
+  static final adjustedWeight =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[2]);
 
   /// see [Recipe.adjustedPressure]
-  static final adjustedPressure = QueryDoubleProperty<Recipe>(_entities[5].properties[3]);
+  static final adjustedPressure =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[3]);
 
   /// see [Recipe.adjustedTemp]
-  static final adjustedTemp = QueryDoubleProperty<Recipe>(_entities[5].properties[4]);
+  static final adjustedTemp =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[4]);
 
   /// see [Recipe.name]
   static final name = QueryStringProperty<Recipe>(_entities[5].properties[5]);
 
   /// see [Recipe.profileId]
-  static final profileId = QueryStringProperty<Recipe>(_entities[5].properties[6]);
+  static final profileId =
+      QueryStringProperty<Recipe>(_entities[5].properties[6]);
 
   /// see [Recipe.grinderDoseWeight]
-  static final grinderDoseWeight = QueryDoubleProperty<Recipe>(_entities[5].properties[7]);
+  static final grinderDoseWeight =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[7]);
 
   /// see [Recipe.grinderSettings]
-  static final grinderSettings = QueryDoubleProperty<Recipe>(_entities[5].properties[8]);
+  static final grinderSettings =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[8]);
 
   /// see [Recipe.isDeleted]
-  static final isDeleted = QueryBooleanProperty<Recipe>(_entities[5].properties[9]);
+  static final isDeleted =
+      QueryBooleanProperty<Recipe>(_entities[5].properties[9]);
 
   /// see [Recipe.isFavorite]
-  static final isFavorite = QueryBooleanProperty<Recipe>(_entities[5].properties[10]);
+  static final isFavorite =
+      QueryBooleanProperty<Recipe>(_entities[5].properties[10]);
 
   /// see [Recipe.ratio1]
-  static final ratio1 = QueryDoubleProperty<Recipe>(_entities[5].properties[11]);
+  static final ratio1 =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[11]);
 
   /// see [Recipe.ratio2]
-  static final ratio2 = QueryDoubleProperty<Recipe>(_entities[5].properties[12]);
+  static final ratio2 =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[12]);
 
   /// see [Recipe.weightWater]
-  static final weightWater = QueryDoubleProperty<Recipe>(_entities[5].properties[13]);
+  static final weightWater =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[13]);
 
   /// see [Recipe.useWater]
-  static final useWater = QueryBooleanProperty<Recipe>(_entities[5].properties[14]);
+  static final useWater =
+      QueryBooleanProperty<Recipe>(_entities[5].properties[14]);
 
   /// see [Recipe.tempWater]
-  static final tempWater = QueryDoubleProperty<Recipe>(_entities[5].properties[15]);
+  static final tempWater =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[15]);
 
   /// see [Recipe.timeWater]
-  static final timeWater = QueryDoubleProperty<Recipe>(_entities[5].properties[16]);
+  static final timeWater =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[16]);
 
   /// see [Recipe.tempSteam]
-  static final tempSteam = QueryDoubleProperty<Recipe>(_entities[5].properties[17]);
+  static final tempSteam =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[17]);
 
   /// see [Recipe.flowSteam]
-  static final flowSteam = QueryDoubleProperty<Recipe>(_entities[5].properties[18]);
+  static final flowSteam =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[18]);
 
   /// see [Recipe.timeSteam]
-  static final timeSteam = QueryDoubleProperty<Recipe>(_entities[5].properties[19]);
+  static final timeSteam =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[19]);
 
   /// see [Recipe.weightMilk]
-  static final weightMilk = QueryDoubleProperty<Recipe>(_entities[5].properties[20]);
+  static final weightMilk =
+      QueryDoubleProperty<Recipe>(_entities[5].properties[20]);
 
   /// see [Recipe.useSteam]
-  static final useSteam = QueryBooleanProperty<Recipe>(_entities[5].properties[21]);
+  static final useSteam =
+      QueryBooleanProperty<Recipe>(_entities[5].properties[21]);
 
   /// see [Recipe.description]
-  static final description = QueryStringProperty<Recipe>(_entities[5].properties[22]);
+  static final description =
+      QueryStringProperty<Recipe>(_entities[5].properties[22]);
 
   /// see [Recipe.grinderModel]
-  static final grinderModel = QueryStringProperty<Recipe>(_entities[5].properties[23]);
+  static final grinderModel =
+      QueryStringProperty<Recipe>(_entities[5].properties[23]);
 
   /// see [Recipe.disableStopOnWeight]
-  static final disableStopOnWeight = QueryBooleanProperty<Recipe>(_entities[5].properties[24]);
+  static final disableStopOnWeight =
+      QueryBooleanProperty<Recipe>(_entities[5].properties[24]);
 }
 
 /// [SettingsEntry] entity fields to define ObjectBox queries.
 class SettingsEntry_ {
   /// see [SettingsEntry.id]
-  static final id = QueryIntegerProperty<SettingsEntry>(_entities[6].properties[0]);
+  static final id =
+      QueryIntegerProperty<SettingsEntry>(_entities[6].properties[0]);
 
   /// see [SettingsEntry.doubleVal]
-  static final doubleVal = QueryDoubleProperty<SettingsEntry>(_entities[6].properties[1]);
+  static final doubleVal =
+      QueryDoubleProperty<SettingsEntry>(_entities[6].properties[1]);
 
   /// see [SettingsEntry.intVal]
-  static final intVal = QueryIntegerProperty<SettingsEntry>(_entities[6].properties[2]);
+  static final intVal =
+      QueryIntegerProperty<SettingsEntry>(_entities[6].properties[2]);
 
   /// see [SettingsEntry.stringVal]
-  static final stringVal = QueryStringProperty<SettingsEntry>(_entities[6].properties[3]);
+  static final stringVal =
+      QueryStringProperty<SettingsEntry>(_entities[6].properties[3]);
 
   /// see [SettingsEntry.boolVal]
-  static final boolVal = QueryBooleanProperty<SettingsEntry>(_entities[6].properties[4]);
+  static final boolVal =
+      QueryBooleanProperty<SettingsEntry>(_entities[6].properties[4]);
 
   /// see [SettingsEntry.key]
-  static final key = QueryStringProperty<SettingsEntry>(_entities[6].properties[5]);
+  static final key =
+      QueryStringProperty<SettingsEntry>(_entities[6].properties[5]);
 
   /// see [SettingsEntry.type]
-  static final type = QueryStringProperty<SettingsEntry>(_entities[6].properties[6]);
+  static final type =
+      QueryStringProperty<SettingsEntry>(_entities[6].properties[6]);
 }

--- a/lib/ui/screens/profiles_advanced_edit_screen.dart
+++ b/lib/ui/screens/profiles_advanced_edit_screen.dart
@@ -394,14 +394,14 @@ class AdvancedProfilesEditScreenState extends State<AdvancedProfilesEditScreen> 
                 const SizedBox(
                   width: 10,
                 ),
-                if (frame.maxVol > 0)
+                if (frame.maxWeight > 0.0)
                   Column(
                     children: [
                       Text(
-                        (frame.maxVol.toStringAsFixed(1)),
+                        (frame.maxWeight.toStringAsFixed(1)),
                         style: style3,
                       ),
-                      Text("ml", style: style3),
+                      Text("g", style: style3),
                     ],
                   ),
               ],

--- a/lib/ui/screens/profiles_advanced_edit_screen.dart
+++ b/lib/ui/screens/profiles_advanced_edit_screen.dart
@@ -672,7 +672,7 @@ class AdvancedProfilesEditScreenState extends State<AdvancedProfilesEditScreen> 
         }),
       ),
       SingleChildScrollView(
-        child: changeMoveOnIf(unit: "sec", title: "Time", min: 0, max: 100, frame, frame.frameLen, (value) {
+        child: changeMoveOnIf(unit: "sec", title: "Time", min: 0, maxValue: 100, frame, frame.frameLen, (value) {
           setState(() {});
           log.info("Changed");
         }),
@@ -1080,111 +1080,183 @@ class AdvancedProfilesEditScreenState extends State<AdvancedProfilesEditScreen> 
     );
   }
 
-  Widget changeMoveOnIf(De1ShotFrameClass frame, double value, Function(De1ShotFrameClass value) valueChanged,
-      {required String unit, required double max, required double min, double? interval, String? title}) {
+  Widget changeMoveOnIf(De1ShotFrameClass frame, double value,
+      Function(De1ShotFrameClass value) valueChanged,
+      {required String unit,
+      required double maxValue,
+      required double min,
+      double? interval,
+      String? title}) {
     bool isComparing = ((frame.flag & De1ShotFrameClass.doCompare) > 0);
+    bool isComparingWeight = frame.maxWeight > 0.0;
     bool isGt = (frame.flag & De1ShotFrameClass.dcGT) > 0;
     bool isFlow = (frame.flag & De1ShotFrameClass.dcCompF) > 0;
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Expanded(
-          child: IntrinsicHeight(
-            child: Padding(
-              padding: const EdgeInsets.all(28.0),
-              child: Column(
-                children: [
-                  Row(
-                    children: [
-                      SizedBox(width: 75, child: Text("Do\ncompare:", style: Theme.of(context).textTheme.labelMedium)),
-                      Switch(
-                        value: isComparing,
-                        onChanged: (value) {
-                          var mask = frame.flag & (255 - De1ShotFrameClass.doCompare);
-                          if (!value) {
-                            frame.flag &= mask;
-                          } else {
-                            frame.flag |= De1ShotFrameClass.doCompare;
-                          }
+    return Padding(
+        padding: const EdgeInsets.all(28.0),
+        child: Column(children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                width: 200,
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        SizedBox(
+                            width: 75,
+                            child: Text("Do\ncompare:",
+                                style:
+                                    Theme.of(context).textTheme.labelMedium)),
+                        Switch(
+                          value: isComparing,
+                          onChanged: (value) {
+                            var mask = frame.flag &
+                                (255 - De1ShotFrameClass.doCompare);
+                            if (!value) {
+                              frame.flag &= mask;
+                            } else {
+                              frame.flag |= De1ShotFrameClass.doCompare;
+                            }
 
-                          valueChanged(frame);
-                        },
+                            valueChanged(frame);
+                          },
+                        ),
+                      ],
+                    ),
+                    if (isComparing)
+                      Row(
+                        children: [
+                          SizedBox(
+                              width: 55,
+                              child: Text("If:",
+                                  style:
+                                      Theme.of(context).textTheme.labelMedium)),
+                          ToggleButtons(
+                            isSelected: [!isFlow, isFlow],
+                            onPressed: (index) {
+                              var mask = frame.flag &
+                                  (255 - De1ShotFrameClass.dcCompF);
+                              if (index == 0) {
+                                frame.flag &= mask;
+                              } else {
+                                frame.flag |= De1ShotFrameClass.dcCompF;
+                              }
+
+                              valueChanged(frame);
+                            },
+                            children: const [Text("Pressure"), Text("Flow")],
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
-                  if (isComparing)
-                    Row(
-                      children: [
-                        SizedBox(width: 55, child: Text("If:", style: Theme.of(context).textTheme.labelMedium)),
-                        ToggleButtons(
-                          isSelected: [!isFlow, isFlow],
-                          onPressed: (index) {
-                            var mask = frame.flag & (255 - De1ShotFrameClass.dcCompF);
-                            if (index == 0) {
-                              frame.flag &= mask;
-                            } else {
-                              frame.flag |= De1ShotFrameClass.dcCompF;
-                            }
+                    if (isComparing)
+                      Row(
+                        children: [
+                          SizedBox(
+                              width: 55,
+                              child: Text("is:",
+                                  style:
+                                      Theme.of(context).textTheme.labelMedium)),
+                          ToggleButtons(
+                            isSelected: [isGt, !isGt],
+                            onPressed: (index) {
+                              // DC_GT
+                              var mask =
+                                  frame.flag & (255 - De1ShotFrameClass.dcGT);
+                              if (index == 1) {
+                                frame.flag &= mask;
+                              } else {
+                                frame.flag |= De1ShotFrameClass.dcGT;
+                              }
 
-                            valueChanged(frame);
-                          },
-                          children: const [Text("Pressure"), Text("Flow")],
-                        ),
-                      ],
-                    ),
-                  if (isComparing)
-                    Row(
-                      children: [
-                        SizedBox(width: 55, child: Text("is:", style: Theme.of(context).textTheme.labelMedium)),
-                        ToggleButtons(
-                          isSelected: [isGt, !isGt],
-                          onPressed: (index) {
-                            // DC_GT
-                            var mask = frame.flag & (255 - De1ShotFrameClass.dcGT);
-                            if (index == 1) {
-                              frame.flag &= mask;
-                            } else {
-                              frame.flag |= De1ShotFrameClass.dcGT;
-                            }
-
-                            valueChanged(frame);
-                          },
-                          children: const [Text(" over "), Text(" below ")],
-                        ),
-                      ],
-                    ),
-                ],
+                              valueChanged(frame);
+                            },
+                            children: const [Text(" over "), Text(" below ")],
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
               ),
-            ),
-          ),
-        ),
-        Expanded(
-          flex: 2,
-          child: Padding(
-            padding: const EdgeInsets.all(28.0),
-            child: SizedBox(
-              height: 160,
-              child: !isComparing
-                  ? null
-                  : changeValueRow(
+              Expanded(
+                flex: 2,
+                child: Visibility(
+                  visible: isComparing,
+                  child: changeValueRow(
                       unit: isFlow ? "ml/s" : "bar",
-                      title: isFlow ? "${isGt ? ">" : "<"} Flow" : "${isGt ? ">" : "<"} Pressure",
+                      title: isFlow
+                          ? "${isGt ? ">" : "<"} Flow"
+                          : "${isGt ? ">" : "<"} Pressure",
                       min: 0,
                       max: 16,
                       interval: 1,
                       frame,
                       frame.triggerVal, (value) {
-                      frame.triggerVal = value;
+                    frame.triggerVal = value;
 
-                      setState(() {});
-                      log.info("Changed");
-                    }),
-            ),
+                    setState(() {});
+                    log.info("Changed");
+                  }),
+                ),
+              ),
+            ],
           ),
-        ),
-      ],
-    );
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                width: 200,
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        SizedBox(
+                            width: 75,
+                            child: Text("Compare weight",
+                                style:
+                                    Theme.of(context).textTheme.labelMedium)),
+                        Switch(
+                          value: isComparingWeight,
+                          onChanged: (value) {
+                            if (value) {
+                              frame.maxWeight = 0.1;
+                            } else {
+                              frame.maxWeight = 0.0;
+                            }
+
+                            valueChanged(frame);
+                          },
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Visibility(
+                  visible: isComparingWeight,
+                  child: changeValueRow(
+                      unit: "g",
+                      title: "> Weight",
+                      min: 0,
+                      max: 50,
+                      interval: 5,
+                      frame,
+                      frame.maxWeight, (value) {
+                    frame.maxWeight = max(value, 0.1);
+
+                    setState(() {});
+                    log.info("Changed");
+                  }),
+                ),
+              ),
+            ],
+          ),
+        ]));
   }
 
   Widget changeValue(De1ShotFrameClass frame, double value, Function(double value) valueChanged,
@@ -1242,10 +1314,7 @@ class AdvancedProfilesEditScreenState extends State<AdvancedProfilesEditScreen> 
 
   Widget changeValueRow(De1ShotFrameClass frame, double value, Function(double value) valueChanged,
       {required String unit, required double max, required double min, double? interval, String? title}) {
-    return IntrinsicHeight(
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
+    return Column(
           children: [
             Row(
               children: [
@@ -1293,8 +1362,6 @@ class AdvancedProfilesEditScreenState extends State<AdvancedProfilesEditScreen> 
               },
             ),
           ],
-        ),
-      ),
-    );
+        );
   }
 }

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -454,6 +454,16 @@ class SettingsScreenState extends State<AppSettingsScreen> {
                     leading: const Icon(Icons.timer),
                     onChange: (value) {},
                   ),
+                  SliderSettingsTile(
+                    title: S.of(context).screenSettingsStopBeforeStepWeightWasReachedS,
+                    settingKey: SettingKeys.stepLimitWeightTimeAdjust.name,
+                    defaultValue: settingsService.stepLimitWeightTimeAdjust,
+                    min: 0.0,
+                    max: 1.0,
+                    step: 0.05,
+                    leading: const Icon(Icons.timer),
+                    onChange: (value) {},
+                  ),
                   SwitchSettingsTile(
                     settingKey: SettingKeys.shotAutoTare.name,
                     defaultValue: settingsService.shotAutoTare,

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -458,7 +458,7 @@ class SettingsScreenState extends State<AppSettingsScreen> {
                     title: S.of(context).screenSettingsStopBeforeStepWeightWasReachedS,
                     settingKey: SettingKeys.stepLimitWeightTimeAdjust.name,
                     defaultValue: settingsService.stepLimitWeightTimeAdjust,
-                    min: 0.0,
+                    min: -1.0,
                     max: 1.0,
                     step: 0.05,
                     leading: const Icon(Icons.timer),

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -455,7 +455,7 @@ class SettingsScreenState extends State<AppSettingsScreen> {
                     onChange: (value) {},
                   ),
                   SliderSettingsTile(
-                    title: S.of(context).screenSettingsStopBeforeStepWeightWasReachedS,
+                    title: "Delay move-on-at-weight [s]",
                     settingKey: SettingKeys.stepLimitWeightTimeAdjust.name,
                     defaultValue: settingsService.stepLimitWeightTimeAdjust,
                     min: -1.0,

--- a/lib/ui/widgets/selectable_steps.dart
+++ b/lib/ui/widgets/selectable_steps.dart
@@ -26,6 +26,33 @@ class SelectableSteps extends StatelessWidget {
   final Function(int)? onCopied;
   final Function(int, int)? onReordered;
 
+  String? getMoveOnSubtitle(De1ShotFrameClass frame) {
+    bool isGt = (frame.flag & De1ShotFrameClass.dcGT) > 0;
+    bool isFlow = (frame.flag & De1ShotFrameClass.dcCompF) > 0;
+    bool isCompared = (frame.flag & De1ShotFrameClass.doCompare) > 0;
+
+    if (!isCompared && frame.maxWeight == 0) {
+      return null;
+    }
+
+    String subtitle = "Move on if ";
+
+    if (isCompared) {
+      subtitle +=
+          "${isFlow ? "flow" : "pressure"} is ${isGt ? "over" : "below"} ${frame.triggerVal.toStringAsFixed(1)} ${isFlow ? "ml/s" : "bar"}";
+
+      if (frame.maxWeight > 0.0) {
+        subtitle += " or ";
+      }
+    }
+
+    if (frame.maxWeight > 0.0) {
+      subtitle += "weight is over ${frame.maxWeight}g";
+    }
+
+    return subtitle;
+  }
+
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
@@ -87,9 +114,11 @@ class SelectableSteps extends StatelessWidget {
                   ),
                   onDismissed: (direction) {
                     log.info(direction);
-                    if (direction == DismissDirection.startToEnd && onDeleted != null) {
+                    if (direction == DismissDirection.startToEnd &&
+                        onDeleted != null) {
                       onDeleted!(index);
-                    } else if (direction == DismissDirection.endToStart && onCopied != null) {
+                    } else if (direction == DismissDirection.endToStart &&
+                        onCopied != null) {
                       onCopied!(index);
                     }
                     // coffeeService.removeRecipe(data.id);
@@ -158,25 +187,31 @@ class SelectableSteps extends StatelessWidget {
 
   Widget getSubtitle(De1ShotFrameClass frame) {
     bool isMix = ((frame.flag & De1ShotFrameClass.tMixTemp) > 0);
-    bool isGt = (frame.flag & De1ShotFrameClass.dcGT) > 0;
-    bool isFlow = (frame.flag & De1ShotFrameClass.dcCompF) > 0;
-    bool isCompared = (frame.flag & De1ShotFrameClass.doCompare) > 0;
     String vol = frame.maxVol > 0 ? " or ${frame.maxVol} ml" : "";
-    String limitFlow = frame.triggerVal > 0 ? "with a pressure limit of ${frame.triggerVal} bar" : "";
-    String limitPressure = frame.triggerVal > 0 ? "with a flow limit of ${frame.triggerVal} ml/s" : "";
+    String limitFlow = frame.triggerVal > 0
+        ? "with a pressure limit of ${frame.triggerVal} bar"
+        : "";
+    String limitPressure = frame.triggerVal > 0
+        ? "with a flow limit of ${frame.triggerVal} ml/s"
+        : "";
     log.info("RenderFrame Test: $frame");
+
+    var moveOnSubtitle = getMoveOnSubtitle(frame);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text("Set ${isMix ? "water" : "coffee"} temperature to ${frame.temp.toStringAsFixed(0)} °C"),
+        Text(
+            "Set ${isMix ? "water" : "coffee"} temperature to ${frame.temp.toStringAsFixed(0)} °C"),
         if (frame.pump != "pressure")
-          Text("pour ${frame.transition} at rate of ${frame.setVal.toStringAsFixed(1)} ml/s $limitFlow"),
-        if (frame.pump == "pressure")
-          Text("Pressurize ${frame.transition} to ${frame.setVal.toStringAsFixed(1)} bar $limitPressure"),
-        Text("For a maximum of ${frame.frameLen.toStringAsFixed(0)} seconds $vol"),
-        if (isCompared)
           Text(
-              "Move on if ${isFlow ? "flow" : "pressure"} is ${isGt ? "over" : "below"} ${frame.triggerVal.toStringAsFixed(1)} bar"),
+              "pour ${frame.transition} at rate of ${frame.setVal.toStringAsFixed(1)} ml/s $limitFlow"),
+        if (frame.pump == "pressure")
+          Text(
+              "Pressurize ${frame.transition} to ${frame.setVal.toStringAsFixed(1)} bar $limitPressure"),
+        Text(
+            "For a maximum of ${frame.frameLen.toStringAsFixed(0)} seconds $vol"),
+        if (moveOnSubtitle != null) Text(moveOnSubtitle),
       ],
     );
   }


### PR DESCRIPTION
I implemented this in a different way to the "stop at weight" feature:
1. I found linear regression did not work well for the common use case of exiting preinfusion/fill stages by waiting for a very small weight reading. Instead, I used Holt's forecasting method. This alone gave pretty good results, but I get even better results by multiplying the forecasted flow rate by a custom heuristic $\frac{b_t}{b_{t-1}}$. The idea is: if the flow rate starts increasing, it probably will have increased even more by the next time we measure it, and same for decreasing.
2. Instead of running in `handleShotData`, I attached a listener to the scale service to work with its data directly. I was having issues where if the DE1 reported twice before the next scale update, then both frames would have the same weight value, but different sample times. This results in the forecasted flow rate dropping off dramatically.

This approach gives really good accuracy. I'll continue testing it for now to see if any of the forecasting variables need tweaking. But I'm feeling confident that this will be more accurate than the TCL app 🙂 