### PR TITLE
feat: enhanced weight/flow weight graphs

### DIFF
--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -1073,77 +1073,77 @@ class EspressoMachineService extends ChangeNotifier {
 
   shotFinished(List<TimedWeightMeasurement> weightMeasurements) async {
     log.info("Save last shot");
-    var cs = Shot();
-
-    var currentRecipe = coffeeService.currentRecipe!;
-    currentRecipe.id = 0;
-    currentRecipe.isShot = true;
-
-    cs.recipe.targetId = coffeeService.addRecipeFromRecipe(currentRecipe);
-    var currentCoffee = coffeeService.currentCoffee!;
-    currentCoffee.id = 0;
-    currentCoffee.isShot = true;
-    cs.coffee.targetId = await coffeeService.addCoffee(currentCoffee);
-
-    // sometimes shotstates get duplicated, so filter those out
-    // TODO: figure out why they're being duplicated
-    final Set<double> seenSampleTimes = {};
-    cs.shotstates.addAll(
-        shotList.entries.where((element) => element.isInterpolated == false));
-    cs.shotstates.retainWhere((el) => seenSampleTimes.add(el.sampleTime));
-
-    final sampleTimes =
-        cs.shotstates.map((state) => state.sampleTime * 1000).toList();
-
-    final weightTimes = weightMeasurements
-        .map(
-            (measurement) => measurement.time.millisecondsSinceEpoch.toDouble())
-        .toList();
-
-    final weightValues = weightMeasurements
-        .map((measurement) => measurement.weight.weight)
-        .toList();
-
-    final interpolatedWeights = interp(sampleTimes, weightTimes, weightValues);
-
-    final flowWeights = interp(sampleTimes, weightTimes,
-        await calculateFlowWeightsForVisualizer(weightMeasurements));
-
-    log.info("WEIGHT VALUES");
-    weightValues.forEach(log.info);
-
-    log.info("WEIGHT TIMES");
-    weightTimes.forEach(log.info);
-
-    log.info("FLOW WEIGHTS");
-    flowWeights.forEach(log.info);
-
-    // apply weights & flowWeights to 1 decimal place
-    cs.shotstates.asMap().forEach((index, state) {
-      state.weight = (interpolatedWeights[index] * 10).round() / 10;
-      state.flowWeight = (flowWeights[index] * 10).round() / 10;
-    });
-
-    cs.pourTime = lastPourTime;
-    cs.profileId = profileService.currentProfile?.id ?? "";
-    cs.targetEspressoWeight = settingsService.targetEspressoWeight;
-    cs.targetTempCorrection = settingsService.targetTempCorrection;
-    cs.doseWeight = coffeeService.currentRecipe?.grinderDoseWeight ?? 0;
-    cs.pourWeight = shotList.entries.last.weight;
-    cs.ratio1 = coffeeService.currentRecipe?.ratio1 ?? 1;
-    cs.ratio2 = coffeeService.currentRecipe?.ratio2 ?? 1;
-
-    cs.grinderSettings = coffeeService.currentRecipe?.grinderSettings ?? 0;
-    cs.grinderName = coffeeService.currentRecipe?.grinderModel ?? "";
-
-    cs.estimatedWeightReachedTime = currentShot.estimatedWeightReachedTime;
-    cs.estimatedWeight_b = currentShot.estimatedWeight_b;
-    cs.estimatedWeight_m = currentShot.estimatedWeight_m;
-    cs.estimatedWeight_tEnd = currentShot.estimatedWeight_tEnd;
-    cs.estimatedWeight_tStart = currentShot.estimatedWeight_tStart;
-
     try {
+      var cs = Shot();
+
+      var currentRecipe = coffeeService.currentRecipe!;
+      currentRecipe.id = 0;
+      currentRecipe.isShot = true;
+
+      cs.recipe.targetId = coffeeService.addRecipeFromRecipe(currentRecipe);
+      var currentCoffee = coffeeService.currentCoffee!;
+      currentCoffee.id = 0;
+      currentCoffee.isShot = true;
+      cs.coffee.targetId = await coffeeService.addCoffee(currentCoffee);
+
+      // sometimes shotstates get duplicated, so filter those out
+      // TODO: figure out why they're being duplicated
+      final Set<double> seenSampleTimes = {};
+      cs.shotstates.addAll(
+          shotList.entries.where((element) => element.isInterpolated == false));
+      cs.shotstates.retainWhere((el) => seenSampleTimes.add(el.sampleTime));
+
+      final sampleTimes =
+          cs.shotstates.map((state) => state.sampleTime * 1000).toList();
+
+      final weightTimes = weightMeasurements
+          .map(
+              (measurement) => measurement.time.millisecondsSinceEpoch.toDouble())
+          .toList();
+
+      final weightValues = weightMeasurements
+          .map((measurement) => measurement.weight.weight)
+          .toList();
+
+      final interpolatedWeights = interp(sampleTimes, weightTimes, weightValues);
+
+      final flowWeights = interp(sampleTimes, weightTimes,
+          await calculateFlowWeightsForVisualizer(weightMeasurements));
+
+      log.info("WEIGHT VALUES");
+      weightValues.forEach(log.info);
+
+      log.info("WEIGHT TIMES");
+      weightTimes.forEach(log.info);
+
+      log.info("FLOW WEIGHTS");
+      flowWeights.forEach(log.info);
+
+      // apply weights & flowWeights to 1 decimal place
+      cs.shotstates.asMap().forEach((index, state) {
+        state.weight = (interpolatedWeights[index] * 10).round() / 10;
+        state.flowWeight = (flowWeights[index] * 10).round() / 10;
+      });
+
+      cs.pourTime = lastPourTime;
+      cs.profileId = profileService.currentProfile?.id ?? "";
+      cs.targetEspressoWeight = settingsService.targetEspressoWeight;
+      cs.targetTempCorrection = settingsService.targetTempCorrection;
+      cs.doseWeight = coffeeService.currentRecipe?.grinderDoseWeight ?? 0;
+      cs.pourWeight = shotList.entries.last.weight;
+      cs.ratio1 = coffeeService.currentRecipe?.ratio1 ?? 1;
+      cs.ratio2 = coffeeService.currentRecipe?.ratio2 ?? 1;
+
+      cs.grinderName = coffeeService.currentRecipe?.grinderModel ?? "";
+      cs.grinderSettings = coffeeService.currentRecipe?.grinderSettings ?? 0;
+
+      cs.estimatedWeightReachedTime = currentShot.estimatedWeightReachedTime;
+      cs.estimatedWeight_b = currentShot.estimatedWeight_b;
+      cs.estimatedWeight_m = currentShot.estimatedWeight_m;
+      cs.estimatedWeight_tEnd = currentShot.estimatedWeight_tEnd;
+      cs.estimatedWeight_tStart = currentShot.estimatedWeight_tStart;
       await coffeeService.addNewShot(cs);
+
       shotList.saveData();
 
       currentShot = cs;

--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -1141,7 +1141,7 @@ class EspressoMachineService extends ChangeNotifier {
       cs.targetEspressoWeight = settingsService.targetEspressoWeight;
       cs.targetTempCorrection = settingsService.targetTempCorrection;
       cs.doseWeight = coffeeService.currentRecipe?.grinderDoseWeight ?? 0;
-      cs.pourWeight = shotList.entries.last.weight;
+      cs.pourWeight = weightMeasurements.last.weight.weight;
       cs.ratio1 = coffeeService.currentRecipe?.ratio1 ?? 1;
       cs.ratio2 = coffeeService.currentRecipe?.ratio2 ?? 1;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   community_charts_common:
     dependency: transitive
     description:
@@ -575,10 +575,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_savgol
-      sha256: "1e0efaf295363ec6b45c153496058b6018e930bf0080e8960543d2892ca5f59d"
+      sha256: "0742b45bb7e40ddb01ca47fdbd2ed778b675287c39c9928bf2dff08d9d6a23db"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1+4"
+    version: "0.0.1+6"
   flutter_settings_screens:
     dependency: "direct main"
     description:
@@ -705,10 +705,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.18.0"
   io:
     dependency: transitive
     description:
@@ -769,18 +769,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -1342,10 +1342,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   sqflite:
     dependency: transitive
     description:
@@ -1430,10 +1430,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.5.1"
   timing:
     dependency: transitive
     description:
@@ -1586,14 +1586,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: "direct main"
     description:
@@ -1635,5 +1627,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.6 <4.0.0"
   flutter: ">=3.10.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  build_cli_annotations:
+    dependency: transitive
+    description:
+      name: build_cli_annotations
+      sha256: b59d2769769efd6c9ff6d4c4cede0be115a566afc591705c2040b707534b1172
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   build_config:
     dependency: transitive
     description:
@@ -381,10 +389,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
@@ -555,6 +563,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.0"
+  flutter_rust_bridge:
+    dependency: transitive
+    description:
+      name: flutter_rust_bridge
+      sha256: e12415c3bce49bcbc3fed383f0ea41ad7d828f6cf0eccba0588ffa5a812fe522
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.82.1"
+  flutter_savgol:
+    dependency: "direct main"
+    description:
+      name: flutter_savgol
+      sha256: "1e0efaf295363ec6b45c153496058b6018e930bf0080e8960543d2892ca5f59d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1+4"
   flutter_settings_screens:
     dependency: "direct main"
     description:
@@ -1061,6 +1085,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  puppeteer:
+    dependency: transitive
+    description:
+      name: puppeteer
+      sha256: "59e723cc5b69537159a7c34efd645dc08a6a1ac4647d7d7823606802c0f93cdb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   reactive_ble_mobile:
     dependency: transitive
     description:
@@ -1101,6 +1133,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  savgol:
+    dependency: transitive
+    description:
+      name: savgol
+      sha256: "1ae0dd160fe3e58e1819ced5a25169b8b34481ceeb5c0f5917d93125fee4d3ad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0+3"
   screen_brightness:
     dependency: "direct main"
     description:
@@ -1410,6 +1450,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -575,10 +575,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_savgol
-      sha256: "0742b45bb7e40ddb01ca47fdbd2ed778b675287c39c9928bf2dff08d9d6a23db"
+      sha256: "853e9f5232c9c296428a08bd7630d652b40b9309b24e75d5767a29b0b1a39d99"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1+6"
+    version: "0.0.1+7"
   flutter_settings_screens:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,6 +90,7 @@ dependencies:
   wakelock_plus: ^1.1.1
   dashboard: ^0.0.3+1
   flutter_colorpicker: ^1.0.3
+  flutter_savgol: ^0.0.1+4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,7 +90,7 @@ dependencies:
   wakelock_plus: ^1.1.1
   dashboard: ^0.0.3+1
   flutter_colorpicker: ^1.0.3
-  flutter_savgol: ^0.0.1+4
+  flutter_savgol: ^0.0.1+6
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,7 +90,7 @@ dependencies:
   wakelock_plus: ^1.1.1
   dashboard: ^0.0.3+1
   flutter_colorpicker: ^1.0.3
-  flutter_savgol: ^0.0.1+6
+  flutter_savgol: ^0.0.1+7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- (minor tweak) Instead of attaching the last read weight measurement to the current shot state, collect _all_ the weight readings and interpolate to the sample times of shot states. This means less data is discarded and the graph has fewer bumps where the scale and DE1 "dropped out of sync". Would love to be able to save the entire weight graph without interpolation but that would require changes elsewhere in the ecosystem.
- (better data accuracy) [Here's a 1:2 shot](https://visualizer.coffee/shots/fb7d37ad-12b2-4fb3-b35b-c9c65721cbea) I pulled today that wound up with something like 36.1g in the cup. But it reads significantly shorter in Visualizer because we stop collecting data as soon as the machine goes to the idle state, even though there's still fluid on its way to the scale. Now, we wait for the flow to drop to near-zero before we store the shot. There is a fallback 2 second timer in case the flow rate forecast is incorrect.
- (the interesting bit!) Instead of uploading the flow rate estimate from the scale service (moving average of 10 weight samples/time), make a smoother one using a [Savitzky-Golay filter](https://en.wikipedia.org/wiki/Savitzky–Golay_filter). This works great! The only complication was that there wasn't an existing Dart implementation, and it seems Dart doesn't yet have a fleshed out mathematics package. [I implemented the filter in Rust](https://github.com/tpict/savgol-rs) and made [Flutter/Dart bindings using flutter_rust_bridge](https://github.com/tpict/flutter_savgol).

Here's a [before](https://visualizer.coffee/shots/72c34725-535b-415e-a13f-184e0925a45f) and [after](https://visualizer.coffee/shots/ce94a8cc-7a36-4c76-98a9-85b64628bb87).
