### PR TITLE
Stop-at-weight fallback

### DIFF
--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -813,37 +813,46 @@ class EspressoMachineService extends ChangeNotifier {
                 // fallback in case predictive SAW failed, and we're over target
                 // weight.
 
-                log.info("Shot weight already reached! Stopping now at ${weight}");
+                log.info("Shot weight already reached! Stopping now at $weight");
                 triggerEndOfShot();
               } else if (_delayedStop == null) {
-              var valuesCount = calcWeightReachedEstimation();
-              if (valuesCount > 0) {
-                var timeToWeight = currentShot.estimatedWeightReachedTime - shot.sampleTimeCorrected;
-                // var timeToWeight = (weight - shot.weight) / shot.flowWeight;
-                shot.timeToWeight = timeToWeight > 0 && timeToWeight < 100 ? timeToWeight : 0;
-                log.info("Time to weight: $timeToWeight ${shot.weight} ${shot.flowWeight}");
-                if (timeToWeight > 0 &&
-                    timeToWeight < 2.5 &&
-                    (settingsService.targetEspressoWeight - shot.weight < 5)) {
-                  log.info("Shot weight reached soon, starting delayed stop");
-                  _delayedStop = Timer(
-                    Duration(
-                        milliseconds: ((timeToWeight - settingsService.targetEspressoWeightTimeAdjust) * 1000).toInt()),
-                    () {
-                      log.info("Shot weight reached now!, stopping ${state.shot!.weight}");
-                      triggerEndOfShot();
-                    },
-                  );
+                var valuesCount = calcWeightReachedEstimation();
+                if (valuesCount > 0) {
+                  var timeToWeight = currentShot.estimatedWeightReachedTime -
+                      shot.sampleTimeCorrected;
+                  // var timeToWeight = (weight - shot.weight) / shot.flowWeight;
+                  shot.timeToWeight =
+                      timeToWeight > 0 && timeToWeight < 100 ? timeToWeight : 0;
+                  log.info(
+                      "Time to weight: $timeToWeight ${shot.weight} ${shot.flowWeight}");
+                  if (timeToWeight > 0 &&
+                      timeToWeight < 2.5 &&
+                      (settingsService.targetEspressoWeight - shot.weight <
+                          5)) {
+                    log.info("Shot weight reached soon, starting delayed stop");
+                    _delayedStop = Timer(
+                      Duration(
+                          milliseconds: ((timeToWeight -
+                                      settingsService
+                                          .targetEspressoWeightTimeAdjust) *
+                                  1000)
+                              .toInt()),
+                      () {
+                        log.info(
+                            "Shot weight reached now!, stopping ${state.shot!.weight}");
+                        triggerEndOfShot();
+                      },
+                    );
+                  }
                 }
-              }
-              // if (weight > 1 && shot.weight + 1 > weight) {
-              //   log.info("Shot Weight reached ${shot.weight} > $weight Portime: $lastPourTime");
+                // if (weight > 1 && shot.weight + 1 > weight) {
+                //   log.info("Shot Weight reached ${shot.weight} > $weight Portime: $lastPourTime");
 
-              //   if (settingsService.shotStopOnWeight) {
-              //     triggerEndOfShot();
-              //   }
-              // }
-            }
+                //   if (settingsService.shotStopOnWeight) {
+                //     triggerEndOfShot();
+                //   }
+                // }
+              }
             }
           }
           break;

--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -1054,7 +1054,7 @@ class EspressoMachineService extends ChangeNotifier {
     if ((isPouring || state.subState == "pre_infuse") &&
         stepWeightLimit > 0.0 &&
         flowRateForecast > 0.0 &&
-        _delayedStop == false) {
+        _delayedStop == null) {
       var currentWeight = weightMeasurementsDuringShot.last;
       var forecastWeight = currentWeight.weight.weight +
           flowRateForecast * (DateTime.now().difference(currentWeight.time)).inMilliseconds;


### PR DESCRIPTION
For atypical profiles whose weight flow doesn't flatten out at the end of the shot, the linear regression algorithm used for stop-at-weight doesn't always work. [Here's an example of a shot that went 38g above its target weight](https://visualizer.coffee/shots/03b1e38c-20b7-4de0-b302-7a7d8d757793) because the weight flow spiked for a moment as it approached the desired weight.

This PR updates the stop-at-weight logic to stop the shot immediately if the scale reading ever goes above the target weight. If the stop had already been scheduled using the linear regression estimate, it will be cancelled.

I think this minimal effort approach will fix the issue fine, as it's most likely to affect these filter-style profiles where weight of the "shot" can have a much larger margin of error, and the outflow is expected to be slower.