### PR TITLE
Refactor how limiters work

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/model/de1shotclasses.dart
+++ b/lib/model/de1shotclasses.dart
@@ -246,6 +246,8 @@ class De1ShotFrameClass // proc spec_shotframe
   @Uint8ListConverter()
   Uint8List bytes = Uint8List(8);
 
+	int get extFrameToWrite => frameToWrite + De1ShotExtFrameClass.extFrameOffset;
+
   De1ShotFrameClass();
 
   static int ctrlF = 0x01; // Are we in Pressure or Flow priority mode?
@@ -405,11 +407,14 @@ class De1ShotFrameClass // proc spec_shotframe
     }
     return "Frame:$name $frameToWrite Flag:$flag/0x${flag.toRadixString(16)} $flagStr Value:$setVal Temp:$temp FrameLen:$frameLen TriggerVal:$triggerVal MaxVol:$maxVol B:$sb";
   }
+
 }
 
 @JsonSerializable()
 class De1ShotExtFrameClass // extended frames
 {
+
+	static const int extFrameOffset = 32;
   int frameToWrite = 0;
   double limiterValue = 0.0;
   double limiterRange = 0.0;

--- a/lib/model/de1shotclasses.dart
+++ b/lib/model/de1shotclasses.dart
@@ -58,6 +58,25 @@ class De1ShotProfile {
 
     return shotFrames.first;
   }
+
+  De1ShotExtFrameClass getExtFrame(De1ShotFrameClass frame) {
+    final log = Logger('getExtFrame');
+		// Make sure we have a valid frame
+		if (shotFrames.isEmpty || !shotFrames.contains(frame)) {
+			log.severe("No frames in profile or frame not in profile");
+			return De1ShotExtFrameClass();
+		}
+		// find extFrame that corresponds to this frame or create a new one
+    De1ShotExtFrameClass extFrame = shotExframes
+        .firstWhere((element) => element.frameToWrite == frame.extFrameToWrite,
+            orElse: () => De1ShotExtFrameClass()
+              ..limiterRange = 0.6
+              ..frameToWrite = frame.extFrameToWrite);
+    if (!shotExframes.contains(extFrame)) {
+      shotExframes.add(extFrame);
+    }
+    return extFrame;
+  }
 }
 
 @JsonSerializable()

--- a/lib/model/services/ble/machine_service.dart
+++ b/lib/model/services/ble/machine_service.dart
@@ -625,7 +625,10 @@ class EspressoMachineService extends ChangeNotifier {
     for (var exFrame in profile.shotExframes) {
       try {
         log.info("Write ExtFrame: $exFrame");
-        await de1!.writeWithResult(Endpoint.frameWrite, exFrame.bytes);
+        if (exFrame.limiterValue > 0) {
+          var bytes = De1ShotExtFrameClass.encodeDe1ExtentionFrame(exFrame);
+          await de1!.writeWithResult(Endpoint.frameWrite, bytes);
+        }
       } catch (ex) {
         log.severe("Error writing exframe $profile $ex");
         return "Error writing ex shot frame $exFrame";

--- a/lib/model/services/state/profile_service.dart
+++ b/lib/model/services/state/profile_service.dart
@@ -574,7 +574,7 @@ class ProfileService extends ChangeNotifier {
 
       if (limiterValue != 0.0 && limiterValue != double.negativeInfinity && limiterRange != double.negativeInfinity) {
         De1ShotExtFrameClass exFrame = De1ShotExtFrameClass();
-        exFrame.frameToWrite = (frameCounter + 32).toInt();
+        exFrame.frameToWrite = (frameCounter + De1ShotExtFrameClass.extFrameOffset).toInt();
         exFrame.limiterValue = limiterValue;
         exFrame.limiterRange = limiterRange;
         shotExframes.add(exFrame);

--- a/lib/ui/screens/profiles_advanced_edit_screen.dart
+++ b/lib/ui/screens/profiles_advanced_edit_screen.dart
@@ -75,7 +75,7 @@ class AdvancedProfilesEditScreenState extends State<AdvancedProfilesEditScreen>
       log.info("Profile-Ext: $element");
     }
 
-    _tabController = TabController(length: 5, vsync: this, initialIndex: 0);
+    _tabController = TabController(length: 4, vsync: this, initialIndex: 0);
   }
 
   @override

--- a/lib/ui/widgets/selectable_steps.dart
+++ b/lib/ui/widgets/selectable_steps.dart
@@ -186,13 +186,14 @@ class SelectableSteps extends StatelessWidget {
   }
 
   Widget getSubtitle(De1ShotFrameClass frame) {
+		De1ShotExtFrameClass extFrame = _profile.getExtFrame(frame);
     bool isMix = ((frame.flag & De1ShotFrameClass.tMixTemp) > 0);
     String vol = frame.maxVol > 0 ? " or ${frame.maxVol} ml" : "";
-    String limitFlow = frame.triggerVal > 0
-        ? "with a pressure limit of ${frame.triggerVal} bar"
+    String limitFlow = extFrame.limiterValue > 0
+        ? "with a pressure limit of ${extFrame.limiterValue} bar"
         : "";
-    String limitPressure = frame.triggerVal > 0
-        ? "with a flow limit of ${frame.triggerVal} ml/s"
+    String limitPressure = extFrame.limiterValue > 0
+        ? "with a flow limit of ${extFrame.limiterValue} ml/s"
         : "";
     log.info("RenderFrame Test: $frame");
 

--- a/lib/ui/widgets/selectable_steps.dart
+++ b/lib/ui/widgets/selectable_steps.dart
@@ -186,7 +186,7 @@ class SelectableSteps extends StatelessWidget {
   }
 
   Widget getSubtitle(De1ShotFrameClass frame) {
-		De1ShotExtFrameClass extFrame = _profile.getExtFrame(frame);
+    De1ShotExtFrameClass extFrame = _profile.getExtFrame(frame);
     bool isMix = ((frame.flag & De1ShotFrameClass.tMixTemp) > 0);
     String vol = frame.maxVol > 0 ? " or ${frame.maxVol} ml" : "";
     String limitFlow = extFrame.limiterValue > 0


### PR DESCRIPTION
I noticed a strange behaviour with my advanced profiles imported through json, or when editing them in the advanced profile editor.

In advanced profile editor, add option to control limiter range, cleanup unused methods for riseAndHold and others.
Refactor logic for when goal is pressure, adjusting flow will adjust the limiter value instead of the frame exit triggerValue and vice versa
Refactor logic for uploading profile, so that bytes from extFrame are encoded and only sent if limiter value is above 0.